### PR TITLE
Streaming Kernels

### DIFF
--- a/Luminary/lib/bvh.c
+++ b/Luminary/lib/bvh.c
@@ -9,7 +9,7 @@
 #include <stdio.h>
 #include <immintrin.h>
 
-#define THRESHOLD_TRIANGLES 1
+#define THRESHOLD_TRIANGLES 3
 #define SAH_SAMPLES 500
 
 struct vec3_p {

--- a/Luminary/lib/bvh.c
+++ b/Luminary/lib/bvh.c
@@ -10,7 +10,7 @@
 #include <immintrin.h>
 
 #define THRESHOLD_TRIANGLES 3
-#define SAH_SAMPLES 500
+#define SAH_SAMPLES 250
 
 struct vec3_p {
   float x;

--- a/Luminary/lib/cuda/brdf.cuh
+++ b/Luminary/lib/cuda/brdf.cuh
@@ -71,7 +71,7 @@ vec3 sample_GGX_VNDF(const vec3 v, const float alpha, const float random1, const
     const vec3 T2 = cross_product(v_hemi, T1);
 
     const float r = sqrtf(random1);
-    const float phi = 2.0f * PI * random2;
+    const float phi = random2;
     const float t1 = r * cosf(phi);
     const float s = 0.5f * (1.0f + v_hemi.z);
     const float t2 = lerp(sqrtf(1.0f - t1 * t1), r * sinf(phi), s);

--- a/Luminary/lib/cuda/bvh.cuh
+++ b/Luminary/lib/cuda/bvh.cuh
@@ -122,10 +122,8 @@ void trace_samples() {
     packed_stptr_invoct.x = 0;
 
     while (1) {
-        int current_sample_finished = packed_stptr_invoct.x == 0 && node_task.y <= 0x00ffffff && triangle_task.y == 0;
-
-        if (current_sample_finished) {
-            if (id >= device_samples_length || id >= device_diffuse_samples * device_amount) break;
+        while (packed_stptr_invoct.x == 0 && node_task.y <= 0x00ffffff && triangle_task.y == 0) {
+            if (id >= device_samples_length) return;
 
             ptr = (float4*)(device_samples + id);
 
@@ -143,7 +141,7 @@ void trace_samples() {
             ray.y = data1.x;
             ray.z = data1.y;
 
-            if (!(float_as_uint(data1.z) & 0x0000ff00)) {
+            if (!(float_as_uint(data1.z) & 0x0100)) {
                 node_task = make_uint2(0, 0);
                 triangle_task = make_uint2(0, 0);
             }

--- a/Luminary/lib/cuda/bvh.cuh
+++ b/Luminary/lib/cuda/bvh.cuh
@@ -97,292 +97,336 @@ unsigned int __bfind(unsigned int a)
         packed_stptr_invoct.x++;                                     \
 }
 
-__device__
-traversal_result traverse_bvh(const vec3 origin, const vec3 ray, const Node8* __restrict__ nodes, const Traversal_Triangle* __restrict__ triangles) {
-    float depth = device_scene.far_clip_distance;
+__global__
+void trace_samples() {
+    vec3 origin, ray;
+    const Node8* nodes = device_scene.nodes;
+    const Traversal_Triangle* triangles = device_scene.traversal_triangles;
+
+    float4* ptr;
+
+    float depth;
+    unsigned int id = threadIdx.x + blockIdx.x * blockDim.x;
 
 	uint2 traversal_stack[STACK_SIZE];
     __shared__ uint2 traversal_stack_sm[128][STACK_SIZE_SM];
 
-    unsigned int hit_id = 0xffffffff;
+    unsigned int hit_id;
 
     vec3 inv_ray;
-    inv_ray.x = 1.0f / (fabsf(ray.x) > eps ? ray.x : copysignf(eps, ray.x));
-    inv_ray.y = 1.0f / (fabsf(ray.y) > eps ? ray.y : copysignf(eps, ray.y));
-    inv_ray.z = 1.0f / (fabsf(ray.z) > eps ? ray.z : copysignf(eps, ray.z));
 
-    uint2 node_task = make_uint2(0, 0b10000000000000000000000000000000);
+    uint2 node_task = make_uint2(0, 0);
     uint2 triangle_task = make_uint2(0, 0);
 
     ushort2 packed_stptr_invoct;
-    packed_stptr_invoct.y = (((ray.x < 0.0f) ? 1 : 0) << 2) | (((ray.y < 0.0f) ? 1 : 0) << 1) | (((ray.z < 0.0f) ? 1 : 0) << 0);
-    packed_stptr_invoct.y = 7 - packed_stptr_invoct.y;
     packed_stptr_invoct.x = 0;
 
     while (1) {
-        if (node_task.y > 0x00ffffff) {
-            const unsigned int hits = node_task.y;
-            const unsigned int imask = node_task.y;
-            const unsigned int child_bit_index = __bfind(hits);
-            const unsigned int child_node_base_index = node_task.x;
+        int current_sample_finished = packed_stptr_invoct.x == 0 && node_task.y <= 0x00ffffff && triangle_task.y == 0;
 
-            node_task.y &= ~(1 << child_bit_index);
+        if (current_sample_finished) {
+            if (id >= device_samples_length || id >= device_diffuse_samples * device_amount) break;
 
+            ptr = (float4*)(device_samples + id);
+
+            float4 data0 = __ldg(ptr + 0);
+            float4 data1 = __ldg(ptr + 1);
+
+            node_task = make_uint2(0, 0b10000000000000000000000000000000);
+            triangle_task = make_uint2(0, 0);
+
+            origin.x = data0.x;
+            origin.y = data0.y;
+            origin.z = data0.z;
+
+            ray.x = data0.w;
+            ray.y = data1.x;
+            ray.z = data1.y;
+
+            if (!(float_as_uint(data1.z) & 0x0000ff00)) {
+                node_task = make_uint2(0, 0);
+                triangle_task = make_uint2(0, 0);
+            }
+
+            inv_ray.x = 1.0f / (fabsf(ray.x) > eps ? ray.x : copysignf(eps, ray.x));
+            inv_ray.y = 1.0f / (fabsf(ray.y) > eps ? ray.y : copysignf(eps, ray.y));
+            inv_ray.z = 1.0f / (fabsf(ray.z) > eps ? ray.z : copysignf(eps, ray.z));
+
+            packed_stptr_invoct.y = (((ray.x < 0.0f) ? 1 : 0) << 2) | (((ray.y < 0.0f) ? 1 : 0) << 1) | (((ray.z < 0.0f) ? 1 : 0) << 0);
+            packed_stptr_invoct.y = 7 - packed_stptr_invoct.y;
+            packed_stptr_invoct.x = 0;
+
+            depth = device_scene.far_clip_distance;
+
+            hit_id = 0xffffffff;
+
+            id += blockDim.x * gridDim.x;
+        }
+
+        while (1) {
             if (node_task.y > 0x00ffffff) {
-                STACK_PUSH(node_task);
-            }
+                const unsigned int hits = node_task.y;
+                const unsigned int imask = node_task.y;
+                const unsigned int child_bit_index = __bfind(hits);
+                const unsigned int child_node_base_index = node_task.x;
 
-            {
-                const unsigned int slot_index = (child_bit_index - 24) ^ (unsigned int)packed_stptr_invoct.y;
-                const unsigned int inverse_octant4 = (unsigned int)packed_stptr_invoct.y * 0x01010101u;
-                const unsigned int relative_index = __popc(imask & ~(0xffffffff << slot_index));
-                const unsigned int child_node_index = child_node_base_index + relative_index;
+                node_task.y &= ~(1 << child_bit_index);
 
-                float4* data_ptr = (float4*)(nodes + child_node_index);
-
-                const float4 data0 = __ldg(data_ptr + 0);
-                const float4 data1 = __ldg(data_ptr + 1);
-                const float4 data2 = __ldg(data_ptr + 2);
-                const float4 data3 = __ldg(data_ptr + 3);
-                const float4 data4 = __ldg(data_ptr + 4);
-
-                vec3 p;
-                p.x = data0.x;
-                p.y = data0.y;
-                p.z = data0.z;
-
-                int3 e;
-                e.x = *((char*)&data0.w + 0);
-                e.y = *((char*)&data0.w + 1);
-                e.z = *((char*)&data0.w + 2);
-
-                node_task.x = float_as_uint(data1.x);
-                triangle_task.x = float_as_uint(data1.y);
-                triangle_task.y = 0;
-                unsigned int hit_mask = 0;
-
-                vec3 scaled_inv_ray;
-                scaled_inv_ray.x = uint_as_float((e.x + 127) << 23) * inv_ray.x;
-                scaled_inv_ray.y = uint_as_float((e.y + 127) << 23) * inv_ray.y;
-                scaled_inv_ray.z = uint_as_float((e.z + 127) << 23) * inv_ray.z;
-
-                vec3 shifted_origin;
-                shifted_origin.x = (p.x - origin.x) * inv_ray.x;
-                shifted_origin.y = (p.y - origin.y) * inv_ray.y;
-                shifted_origin.z = (p.z - origin.z) * inv_ray.z;
-
-                {
-                    const unsigned int meta4 = float_as_int(data1.z);
-                    const unsigned int is_inner4 = (meta4 & (meta4 << 1)) & 0x10101010;
-                    const unsigned int inner_mask4 = sign_extend_s8x4(is_inner4 << 3);
-                    const unsigned int bit_index4 = (meta4 ^ (inverse_octant4 & inner_mask4)) & 0x1f1f1f1f;
-                    const unsigned int child_bits4 = (meta4 >> 5) & 0x07070707;
-
-                    const unsigned int low_x = (inv_ray.x < 0.0f) ? float_as_uint(data3.z) : float_as_uint(data2.x);
-                    const unsigned int high_x = (inv_ray.x < 0.0f) ? float_as_uint(data2.x) : float_as_uint(data3.z);
-                    const unsigned int low_y = (inv_ray.y < 0.0f) ? float_as_uint(data4.x) : float_as_uint(data2.z);
-                    const unsigned int high_y = (inv_ray.y < 0.0f) ? float_as_uint(data2.z) : float_as_uint(data4.x);
-                    const unsigned int low_z = (inv_ray.z < 0.0f) ? float_as_uint(data4.z) : float_as_uint(data3.x);
-                    const unsigned int high_z = (inv_ray.z < 0.0f) ? float_as_uint(data3.x) : float_as_uint(data4.z);
-
-                    float min_x[4];
-                    float max_x[4];
-                    float min_y[4];
-                    float max_y[4];
-                    float min_z[4];
-                    float max_z[4];
-
-                    min_x[0] = get_8bit(low_x, 0) * scaled_inv_ray.x + shifted_origin.x;
-                    min_x[1] = get_8bit(low_x, 8) * scaled_inv_ray.x + shifted_origin.x;
-                    min_x[2] = get_8bit(low_x, 16) * scaled_inv_ray.x + shifted_origin.x;
-                    min_x[3] = get_8bit(low_x, 24) * scaled_inv_ray.x + shifted_origin.x;
-
-                    max_x[0] = get_8bit(high_x, 0) * scaled_inv_ray.x + shifted_origin.x;
-                    max_x[1] = get_8bit(high_x, 8) * scaled_inv_ray.x + shifted_origin.x;
-                    max_x[2] = get_8bit(high_x, 16) * scaled_inv_ray.x + shifted_origin.x;
-                    max_x[3] = get_8bit(high_x, 24) * scaled_inv_ray.x + shifted_origin.x;
-
-                    min_y[0] = get_8bit(low_y, 0) * scaled_inv_ray.y + shifted_origin.y;
-                    min_y[1] = get_8bit(low_y, 8) * scaled_inv_ray.y + shifted_origin.y;
-                    min_y[2] = get_8bit(low_y, 16) * scaled_inv_ray.y + shifted_origin.y;
-                    min_y[3] = get_8bit(low_y, 24) * scaled_inv_ray.y + shifted_origin.y;
-
-                    max_y[0] = get_8bit(high_y, 0) * scaled_inv_ray.y + shifted_origin.y;
-                    max_y[1] = get_8bit(high_y, 8) * scaled_inv_ray.y + shifted_origin.y;
-                    max_y[2] = get_8bit(high_y, 16) * scaled_inv_ray.y + shifted_origin.y;
-                    max_y[3] = get_8bit(high_y, 24) * scaled_inv_ray.y + shifted_origin.y;
-
-                    min_z[0] = get_8bit(low_z, 0) * scaled_inv_ray.z + shifted_origin.z;
-                    min_z[1] = get_8bit(low_z, 8) * scaled_inv_ray.z + shifted_origin.z;
-                    min_z[2] = get_8bit(low_z, 16) * scaled_inv_ray.z + shifted_origin.z;
-                    min_z[3] = get_8bit(low_z, 24) * scaled_inv_ray.z + shifted_origin.z;
-
-                    max_z[0] = get_8bit(high_z, 0) * scaled_inv_ray.z + shifted_origin.z;
-                    max_z[1] = get_8bit(high_z, 8) * scaled_inv_ray.z + shifted_origin.z;
-                    max_z[2] = get_8bit(high_z, 16) * scaled_inv_ray.z + shifted_origin.z;
-                    max_z[3] = get_8bit(high_z, 24) * scaled_inv_ray.z + shifted_origin.z;
-
-                    float slab_min, slab_max;
-                    int intersection;
-
-                    slab_min = fmaxf(fmax_fmax(min_x[0], min_y[0], min_z[0]), eps);
-                    slab_max = fminf(fmin_fmin(max_x[0], max_y[0], max_z[0]), depth);
-                    intersection = slab_min <= slab_max;
-
-                    if (intersection)
-                        asm("vshl.u32.u32.u32.wrap.add %0, %1.b0, %2.b0, %3;" : "=r"(hit_mask) : "r"(child_bits4), "r"(bit_index4), "r"(hit_mask));
-
-                    slab_min = fmaxf(fmax_fmax(min_x[1], min_y[1], min_z[1]), eps);
-                    slab_max = fminf(fmin_fmin(max_x[1], max_y[1], max_z[1]), depth);
-                    intersection = slab_min <= slab_max;
-
-                    if (intersection)
-                        asm("vshl.u32.u32.u32.wrap.add %0, %1.b1, %2.b1, %3;" : "=r"(hit_mask) : "r"(child_bits4), "r"(bit_index4), "r"(hit_mask));
-
-                    slab_min = fmaxf(fmax_fmax(min_x[2], min_y[2], min_z[2]), eps);
-                    slab_max = fminf(fmin_fmin(max_x[2], max_y[2], max_z[2]), depth);
-                    intersection = slab_min <= slab_max;
-
-                    if (intersection)
-                        asm("vshl.u32.u32.u32.wrap.add %0, %1.b2, %2.b2, %3;" : "=r"(hit_mask) : "r"(child_bits4), "r"(bit_index4), "r"(hit_mask));
-
-                    slab_min = fmaxf(fmax_fmax(min_x[3], min_y[3], min_z[3]), eps);
-                    slab_max = fminf(fmin_fmin(max_x[3], max_y[3], max_z[3]), depth);
-                    intersection = slab_min <= slab_max;
-
-                    if (intersection)
-                        asm("vshl.u32.u32.u32.wrap.add %0, %1.b3, %2.b3, %3;" : "=r"(hit_mask) : "r"(child_bits4), "r"(bit_index4), "r"(hit_mask));
+                if (node_task.y > 0x00ffffff) {
+                    STACK_PUSH(node_task);
                 }
 
                 {
-                    const unsigned int meta4 = float_as_int(data1.w);
-                    const unsigned int is_inner4 = (meta4 & (meta4 << 1)) & 0x10101010;
-                    const unsigned int inner_mask4 = sign_extend_s8x4(is_inner4 << 3);
-                    const unsigned int bit_index4 = (meta4 ^ (inverse_octant4 & inner_mask4)) & 0x1f1f1f1f;
-                    const unsigned int child_bits4 = (meta4 >> 5) & 0x07070707;
+                    const unsigned int slot_index = (child_bit_index - 24) ^ (unsigned int)packed_stptr_invoct.y;
+                    const unsigned int inverse_octant4 = (unsigned int)packed_stptr_invoct.y * 0x01010101u;
+                    const unsigned int relative_index = __popc(imask & ~(0xffffffff << slot_index));
+                    const unsigned int child_node_index = child_node_base_index + relative_index;
 
-                    const unsigned int low_x = (inv_ray.x < 0.0f) ? float_as_uint(data3.w) : float_as_uint(data2.y);
-                    const unsigned int high_x = (inv_ray.x < 0.0f) ? float_as_uint(data2.y) : float_as_uint(data3.w);
-                    const unsigned int low_y = (inv_ray.y < 0.0f) ? float_as_uint(data4.y) : float_as_uint(data2.w);
-                    const unsigned int high_y = (inv_ray.y < 0.0f) ? float_as_uint(data2.w) : float_as_uint(data4.y);
-                    const unsigned int low_z = (inv_ray.z < 0.0f) ? float_as_uint(data4.w) : float_as_uint(data3.y);
-                    const unsigned int high_z = (inv_ray.z < 0.0f) ? float_as_uint(data3.y) : float_as_uint(data4.w);
+                    float4* data_ptr = (float4*)(nodes + child_node_index);
 
-                    float min_x[4];
-                    float max_x[4];
-                    float min_y[4];
-                    float max_y[4];
-                    float min_z[4];
-                    float max_z[4];
+                    const float4 data0 = __ldg(data_ptr + 0);
+                    const float4 data1 = __ldg(data_ptr + 1);
+                    const float4 data2 = __ldg(data_ptr + 2);
+                    const float4 data3 = __ldg(data_ptr + 3);
+                    const float4 data4 = __ldg(data_ptr + 4);
 
-                    min_x[0] = get_8bit(low_x, 0) * scaled_inv_ray.x + shifted_origin.x;
-                    min_x[1] = get_8bit(low_x, 8) * scaled_inv_ray.x + shifted_origin.x;
-                    min_x[2] = get_8bit(low_x, 16) * scaled_inv_ray.x + shifted_origin.x;
-                    min_x[3] = get_8bit(low_x, 24) * scaled_inv_ray.x + shifted_origin.x;
+                    vec3 p;
+                    p.x = data0.x;
+                    p.y = data0.y;
+                    p.z = data0.z;
 
-                    max_x[0] = get_8bit(high_x, 0) * scaled_inv_ray.x + shifted_origin.x;
-                    max_x[1] = get_8bit(high_x, 8) * scaled_inv_ray.x + shifted_origin.x;
-                    max_x[2] = get_8bit(high_x, 16) * scaled_inv_ray.x + shifted_origin.x;
-                    max_x[3] = get_8bit(high_x, 24) * scaled_inv_ray.x + shifted_origin.x;
+                    int3 e;
+                    e.x = *((char*)&data0.w + 0);
+                    e.y = *((char*)&data0.w + 1);
+                    e.z = *((char*)&data0.w + 2);
 
-                    min_y[0] = get_8bit(low_y, 0) * scaled_inv_ray.y + shifted_origin.y;
-                    min_y[1] = get_8bit(low_y, 8) * scaled_inv_ray.y + shifted_origin.y;
-                    min_y[2] = get_8bit(low_y, 16) * scaled_inv_ray.y + shifted_origin.y;
-                    min_y[3] = get_8bit(low_y, 24) * scaled_inv_ray.y + shifted_origin.y;
+                    node_task.x = float_as_uint(data1.x);
+                    triangle_task.x = float_as_uint(data1.y);
+                    triangle_task.y = 0;
+                    unsigned int hit_mask = 0;
 
-                    max_y[0] = get_8bit(high_y, 0) * scaled_inv_ray.y + shifted_origin.y;
-                    max_y[1] = get_8bit(high_y, 8) * scaled_inv_ray.y + shifted_origin.y;
-                    max_y[2] = get_8bit(high_y, 16) * scaled_inv_ray.y + shifted_origin.y;
-                    max_y[3] = get_8bit(high_y, 24) * scaled_inv_ray.y + shifted_origin.y;
+                    vec3 scaled_inv_ray;
+                    scaled_inv_ray.x = uint_as_float((e.x + 127) << 23) * inv_ray.x;
+                    scaled_inv_ray.y = uint_as_float((e.y + 127) << 23) * inv_ray.y;
+                    scaled_inv_ray.z = uint_as_float((e.z + 127) << 23) * inv_ray.z;
 
-                    min_z[0] = get_8bit(low_z, 0) * scaled_inv_ray.z + shifted_origin.z;
-                    min_z[1] = get_8bit(low_z, 8) * scaled_inv_ray.z + shifted_origin.z;
-                    min_z[2] = get_8bit(low_z, 16) * scaled_inv_ray.z + shifted_origin.z;
-                    min_z[3] = get_8bit(low_z, 24) * scaled_inv_ray.z + shifted_origin.z;
+                    vec3 shifted_origin;
+                    shifted_origin.x = (p.x - origin.x) * inv_ray.x;
+                    shifted_origin.y = (p.y - origin.y) * inv_ray.y;
+                    shifted_origin.z = (p.z - origin.z) * inv_ray.z;
 
-                    max_z[0] = get_8bit(high_z, 0) * scaled_inv_ray.z + shifted_origin.z;
-                    max_z[1] = get_8bit(high_z, 8) * scaled_inv_ray.z + shifted_origin.z;
-                    max_z[2] = get_8bit(high_z, 16) * scaled_inv_ray.z + shifted_origin.z;
-                    max_z[3] = get_8bit(high_z, 24) * scaled_inv_ray.z + shifted_origin.z;
+                    {
+                        const unsigned int meta4 = float_as_int(data1.z);
+                        const unsigned int is_inner4 = (meta4 & (meta4 << 1)) & 0x10101010;
+                        const unsigned int inner_mask4 = sign_extend_s8x4(is_inner4 << 3);
+                        const unsigned int bit_index4 = (meta4 ^ (inverse_octant4 & inner_mask4)) & 0x1f1f1f1f;
+                        const unsigned int child_bits4 = (meta4 >> 5) & 0x07070707;
 
-                    float slab_min, slab_max;
-                    int intersection;
+                        const unsigned int low_x = (inv_ray.x < 0.0f) ? float_as_uint(data3.z) : float_as_uint(data2.x);
+                        const unsigned int high_x = (inv_ray.x < 0.0f) ? float_as_uint(data2.x) : float_as_uint(data3.z);
+                        const unsigned int low_y = (inv_ray.y < 0.0f) ? float_as_uint(data4.x) : float_as_uint(data2.z);
+                        const unsigned int high_y = (inv_ray.y < 0.0f) ? float_as_uint(data2.z) : float_as_uint(data4.x);
+                        const unsigned int low_z = (inv_ray.z < 0.0f) ? float_as_uint(data4.z) : float_as_uint(data3.x);
+                        const unsigned int high_z = (inv_ray.z < 0.0f) ? float_as_uint(data3.x) : float_as_uint(data4.z);
 
-                    slab_min = fmaxf(fmax_fmax(min_x[0], min_y[0], min_z[0]), eps);
-                    slab_max = fminf(fmin_fmin(max_x[0], max_y[0], max_z[0]), depth);
-                    intersection = slab_min <= slab_max;
+                        float min_x[4];
+                        float max_x[4];
+                        float min_y[4];
+                        float max_y[4];
+                        float min_z[4];
+                        float max_z[4];
 
-                    if (intersection)
-                        asm("vshl.u32.u32.u32.wrap.add %0, %1.b0, %2.b0, %3;" : "=r"(hit_mask) : "r"(child_bits4), "r"(bit_index4), "r"(hit_mask));
+                        min_x[0] = get_8bit(low_x, 0) * scaled_inv_ray.x + shifted_origin.x;
+                        min_x[1] = get_8bit(low_x, 8) * scaled_inv_ray.x + shifted_origin.x;
+                        min_x[2] = get_8bit(low_x, 16) * scaled_inv_ray.x + shifted_origin.x;
+                        min_x[3] = get_8bit(low_x, 24) * scaled_inv_ray.x + shifted_origin.x;
 
-                    slab_min = fmaxf(fmax_fmax(min_x[1], min_y[1], min_z[1]), eps);
-                    slab_max = fminf(fmin_fmin(max_x[1], max_y[1], max_z[1]), depth);
-                    intersection = slab_min <= slab_max;
+                        max_x[0] = get_8bit(high_x, 0) * scaled_inv_ray.x + shifted_origin.x;
+                        max_x[1] = get_8bit(high_x, 8) * scaled_inv_ray.x + shifted_origin.x;
+                        max_x[2] = get_8bit(high_x, 16) * scaled_inv_ray.x + shifted_origin.x;
+                        max_x[3] = get_8bit(high_x, 24) * scaled_inv_ray.x + shifted_origin.x;
 
-                    if (intersection)
-                        asm("vshl.u32.u32.u32.wrap.add %0, %1.b1, %2.b1, %3;" : "=r"(hit_mask) : "r"(child_bits4), "r"(bit_index4), "r"(hit_mask));
+                        min_y[0] = get_8bit(low_y, 0) * scaled_inv_ray.y + shifted_origin.y;
+                        min_y[1] = get_8bit(low_y, 8) * scaled_inv_ray.y + shifted_origin.y;
+                        min_y[2] = get_8bit(low_y, 16) * scaled_inv_ray.y + shifted_origin.y;
+                        min_y[3] = get_8bit(low_y, 24) * scaled_inv_ray.y + shifted_origin.y;
 
-                    slab_min = fmaxf(fmax_fmax(min_x[2], min_y[2], min_z[2]), eps);
-                    slab_max = fminf(fmin_fmin(max_x[2], max_y[2], max_z[2]), depth);
-                    intersection = slab_min <= slab_max;
+                        max_y[0] = get_8bit(high_y, 0) * scaled_inv_ray.y + shifted_origin.y;
+                        max_y[1] = get_8bit(high_y, 8) * scaled_inv_ray.y + shifted_origin.y;
+                        max_y[2] = get_8bit(high_y, 16) * scaled_inv_ray.y + shifted_origin.y;
+                        max_y[3] = get_8bit(high_y, 24) * scaled_inv_ray.y + shifted_origin.y;
 
-                    if (intersection)
-                        asm("vshl.u32.u32.u32.wrap.add %0, %1.b2, %2.b2, %3;" : "=r"(hit_mask) : "r"(child_bits4), "r"(bit_index4), "r"(hit_mask));
+                        min_z[0] = get_8bit(low_z, 0) * scaled_inv_ray.z + shifted_origin.z;
+                        min_z[1] = get_8bit(low_z, 8) * scaled_inv_ray.z + shifted_origin.z;
+                        min_z[2] = get_8bit(low_z, 16) * scaled_inv_ray.z + shifted_origin.z;
+                        min_z[3] = get_8bit(low_z, 24) * scaled_inv_ray.z + shifted_origin.z;
 
-                    slab_min = fmaxf(fmax_fmax(min_x[3], min_y[3], min_z[3]), eps);
-                    slab_max = fminf(fmin_fmin(max_x[3], max_y[3], max_z[3]), depth);
-                    intersection = slab_min <= slab_max;
+                        max_z[0] = get_8bit(high_z, 0) * scaled_inv_ray.z + shifted_origin.z;
+                        max_z[1] = get_8bit(high_z, 8) * scaled_inv_ray.z + shifted_origin.z;
+                        max_z[2] = get_8bit(high_z, 16) * scaled_inv_ray.z + shifted_origin.z;
+                        max_z[3] = get_8bit(high_z, 24) * scaled_inv_ray.z + shifted_origin.z;
 
-                    if (intersection)
-                        asm("vshl.u32.u32.u32.wrap.add %0, %1.b3, %2.b3, %3;" : "=r"(hit_mask) : "r"(child_bits4), "r"(bit_index4), "r"(hit_mask));
+                        float slab_min, slab_max;
+                        int intersection;
+
+                        slab_min = fmaxf(fmax_fmax(min_x[0], min_y[0], min_z[0]), eps);
+                        slab_max = fminf(fmin_fmin(max_x[0], max_y[0], max_z[0]), depth);
+                        intersection = slab_min <= slab_max;
+
+                        if (intersection)
+                            asm("vshl.u32.u32.u32.wrap.add %0, %1.b0, %2.b0, %3;" : "=r"(hit_mask) : "r"(child_bits4), "r"(bit_index4), "r"(hit_mask));
+
+                        slab_min = fmaxf(fmax_fmax(min_x[1], min_y[1], min_z[1]), eps);
+                        slab_max = fminf(fmin_fmin(max_x[1], max_y[1], max_z[1]), depth);
+                        intersection = slab_min <= slab_max;
+
+                        if (intersection)
+                            asm("vshl.u32.u32.u32.wrap.add %0, %1.b1, %2.b1, %3;" : "=r"(hit_mask) : "r"(child_bits4), "r"(bit_index4), "r"(hit_mask));
+
+                        slab_min = fmaxf(fmax_fmax(min_x[2], min_y[2], min_z[2]), eps);
+                        slab_max = fminf(fmin_fmin(max_x[2], max_y[2], max_z[2]), depth);
+                        intersection = slab_min <= slab_max;
+
+                        if (intersection)
+                            asm("vshl.u32.u32.u32.wrap.add %0, %1.b2, %2.b2, %3;" : "=r"(hit_mask) : "r"(child_bits4), "r"(bit_index4), "r"(hit_mask));
+
+                        slab_min = fmaxf(fmax_fmax(min_x[3], min_y[3], min_z[3]), eps);
+                        slab_max = fminf(fmin_fmin(max_x[3], max_y[3], max_z[3]), depth);
+                        intersection = slab_min <= slab_max;
+
+                        if (intersection)
+                            asm("vshl.u32.u32.u32.wrap.add %0, %1.b3, %2.b3, %3;" : "=r"(hit_mask) : "r"(child_bits4), "r"(bit_index4), "r"(hit_mask));
+                    }
+
+                    {
+                        const unsigned int meta4 = float_as_int(data1.w);
+                        const unsigned int is_inner4 = (meta4 & (meta4 << 1)) & 0x10101010;
+                        const unsigned int inner_mask4 = sign_extend_s8x4(is_inner4 << 3);
+                        const unsigned int bit_index4 = (meta4 ^ (inverse_octant4 & inner_mask4)) & 0x1f1f1f1f;
+                        const unsigned int child_bits4 = (meta4 >> 5) & 0x07070707;
+
+                        const unsigned int low_x = (inv_ray.x < 0.0f) ? float_as_uint(data3.w) : float_as_uint(data2.y);
+                        const unsigned int high_x = (inv_ray.x < 0.0f) ? float_as_uint(data2.y) : float_as_uint(data3.w);
+                        const unsigned int low_y = (inv_ray.y < 0.0f) ? float_as_uint(data4.y) : float_as_uint(data2.w);
+                        const unsigned int high_y = (inv_ray.y < 0.0f) ? float_as_uint(data2.w) : float_as_uint(data4.y);
+                        const unsigned int low_z = (inv_ray.z < 0.0f) ? float_as_uint(data4.w) : float_as_uint(data3.y);
+                        const unsigned int high_z = (inv_ray.z < 0.0f) ? float_as_uint(data3.y) : float_as_uint(data4.w);
+
+                        float min_x[4];
+                        float max_x[4];
+                        float min_y[4];
+                        float max_y[4];
+                        float min_z[4];
+                        float max_z[4];
+
+                        min_x[0] = get_8bit(low_x, 0) * scaled_inv_ray.x + shifted_origin.x;
+                        min_x[1] = get_8bit(low_x, 8) * scaled_inv_ray.x + shifted_origin.x;
+                        min_x[2] = get_8bit(low_x, 16) * scaled_inv_ray.x + shifted_origin.x;
+                        min_x[3] = get_8bit(low_x, 24) * scaled_inv_ray.x + shifted_origin.x;
+
+                        max_x[0] = get_8bit(high_x, 0) * scaled_inv_ray.x + shifted_origin.x;
+                        max_x[1] = get_8bit(high_x, 8) * scaled_inv_ray.x + shifted_origin.x;
+                        max_x[2] = get_8bit(high_x, 16) * scaled_inv_ray.x + shifted_origin.x;
+                        max_x[3] = get_8bit(high_x, 24) * scaled_inv_ray.x + shifted_origin.x;
+
+                        min_y[0] = get_8bit(low_y, 0) * scaled_inv_ray.y + shifted_origin.y;
+                        min_y[1] = get_8bit(low_y, 8) * scaled_inv_ray.y + shifted_origin.y;
+                        min_y[2] = get_8bit(low_y, 16) * scaled_inv_ray.y + shifted_origin.y;
+                        min_y[3] = get_8bit(low_y, 24) * scaled_inv_ray.y + shifted_origin.y;
+
+                        max_y[0] = get_8bit(high_y, 0) * scaled_inv_ray.y + shifted_origin.y;
+                        max_y[1] = get_8bit(high_y, 8) * scaled_inv_ray.y + shifted_origin.y;
+                        max_y[2] = get_8bit(high_y, 16) * scaled_inv_ray.y + shifted_origin.y;
+                        max_y[3] = get_8bit(high_y, 24) * scaled_inv_ray.y + shifted_origin.y;
+
+                        min_z[0] = get_8bit(low_z, 0) * scaled_inv_ray.z + shifted_origin.z;
+                        min_z[1] = get_8bit(low_z, 8) * scaled_inv_ray.z + shifted_origin.z;
+                        min_z[2] = get_8bit(low_z, 16) * scaled_inv_ray.z + shifted_origin.z;
+                        min_z[3] = get_8bit(low_z, 24) * scaled_inv_ray.z + shifted_origin.z;
+
+                        max_z[0] = get_8bit(high_z, 0) * scaled_inv_ray.z + shifted_origin.z;
+                        max_z[1] = get_8bit(high_z, 8) * scaled_inv_ray.z + shifted_origin.z;
+                        max_z[2] = get_8bit(high_z, 16) * scaled_inv_ray.z + shifted_origin.z;
+                        max_z[3] = get_8bit(high_z, 24) * scaled_inv_ray.z + shifted_origin.z;
+
+                        float slab_min, slab_max;
+                        int intersection;
+
+                        slab_min = fmaxf(fmax_fmax(min_x[0], min_y[0], min_z[0]), eps);
+                        slab_max = fminf(fmin_fmin(max_x[0], max_y[0], max_z[0]), depth);
+                        intersection = slab_min <= slab_max;
+
+                        if (intersection)
+                            asm("vshl.u32.u32.u32.wrap.add %0, %1.b0, %2.b0, %3;" : "=r"(hit_mask) : "r"(child_bits4), "r"(bit_index4), "r"(hit_mask));
+
+                        slab_min = fmaxf(fmax_fmax(min_x[1], min_y[1], min_z[1]), eps);
+                        slab_max = fminf(fmin_fmin(max_x[1], max_y[1], max_z[1]), depth);
+                        intersection = slab_min <= slab_max;
+
+                        if (intersection)
+                            asm("vshl.u32.u32.u32.wrap.add %0, %1.b1, %2.b1, %3;" : "=r"(hit_mask) : "r"(child_bits4), "r"(bit_index4), "r"(hit_mask));
+
+                        slab_min = fmaxf(fmax_fmax(min_x[2], min_y[2], min_z[2]), eps);
+                        slab_max = fminf(fmin_fmin(max_x[2], max_y[2], max_z[2]), depth);
+                        intersection = slab_min <= slab_max;
+
+                        if (intersection)
+                            asm("vshl.u32.u32.u32.wrap.add %0, %1.b2, %2.b2, %3;" : "=r"(hit_mask) : "r"(child_bits4), "r"(bit_index4), "r"(hit_mask));
+
+                        slab_min = fmaxf(fmax_fmax(min_x[3], min_y[3], min_z[3]), eps);
+                        slab_max = fminf(fmin_fmin(max_x[3], max_y[3], max_z[3]), depth);
+                        intersection = slab_min <= slab_max;
+
+                        if (intersection)
+                            asm("vshl.u32.u32.u32.wrap.add %0, %1.b3, %2.b3, %3;" : "=r"(hit_mask) : "r"(child_bits4), "r"(bit_index4), "r"(hit_mask));
+                    }
+
+                    node_task.y = (hit_mask & 0xff000000) | (*((unsigned char*)&data0.w + 3));
+                    triangle_task.y = hit_mask & 0x00ffffff;
+                }
+            }
+            else {
+                triangle_task = node_task;
+                node_task = make_uint2(0, 0);
+            }
+
+            const int active_threads = __popc(__activemask());
+
+            while (triangle_task.y != 0) {
+                const int threshold = active_threads * 0.4f;
+                const int triangle_threads = __popc(__activemask());
+
+                if (triangle_threads < threshold) {
+                    STACK_PUSH(triangle_task);
+                    break;
                 }
 
-                node_task.y = (hit_mask & 0xff000000) | (*((unsigned char*)&data0.w + 3));
-                triangle_task.y = hit_mask & 0x00ffffff;
-            }
-        }
-        else {
-            triangle_task = node_task;
-            node_task = make_uint2(0, 0);
-        }
+                const int triangle_index = __bfind(triangle_task.y);
 
-        const int active_threads = __popc(__activemask());
+                const float d = bvh_triangle_intersection((float4*)(triangles + triangle_index + triangle_task.x), origin, ray);
 
-        while (triangle_task.y != 0) {
-            const int threshold = active_threads * 0.4f;
-            const int triangle_threads = __popc(__activemask());
+                if (d < depth) {
+                    depth = d;
+                    hit_id = triangle_index + triangle_task.x;
+                }
 
-            if (triangle_threads < threshold) {
-                STACK_PUSH(triangle_task);
-                break;
+                triangle_task.y &= ~(1 << triangle_index);
             }
 
-            const int triangle_index = __bfind(triangle_task.y);
+            if (node_task.y <= 0x00ffffff) {
+                if (packed_stptr_invoct.x > 0) {
+                    STACK_POP(node_task);
+                } else {
+                    float4 write_back;
+                    write_back.x = depth;
+                    write_back.y = uint_as_float(hit_id);
 
-            const float d = bvh_triangle_intersection((float4*)(triangles + triangle_index + triangle_task.x), origin, ray);
-
-            if (d < depth) {
-                depth = d;
-                hit_id = triangle_index + triangle_task.x;
-            }
-
-            triangle_task.y &= ~(1 << triangle_index);
-        }
-
-        if (node_task.y <= 0x00ffffff) {
-            if (packed_stptr_invoct.x > 0) {
-                STACK_POP(node_task);
-            } else {
-                break;
+                    __stwt(ptr + 4, write_back);
+                    break;
+                }
             }
         }
     }
-
-    traversal_result result;
-    result.hit_id = hit_id;
-    result.depth = depth;
-
-    return result;
 }
 
 #endif /* CU_BVH_H */

--- a/Luminary/lib/cuda/bvh.cuh
+++ b/Luminary/lib/cuda/bvh.cuh
@@ -97,7 +97,7 @@ unsigned int __bfind(unsigned int a)
         packed_stptr_invoct.x++;                                     \
 }
 
-__global__
+__global__ __launch_bounds__(THREADS_PER_BLOCK)
 void trace_samples() {
     vec3 origin, ray;
     const Node8* nodes = device_scene.nodes;

--- a/Luminary/lib/cuda/bvh.cuh
+++ b/Luminary/lib/cuda/bvh.cuh
@@ -125,7 +125,7 @@ void trace_samples() {
         while (packed_stptr_invoct.x == 0 && node_task.y <= 0x00ffffff && triangle_task.y == 0) {
             if (id >= device_samples_length) return;
 
-            ptr = (float4*)(device_samples + id);
+            ptr = (float4*)(device_active_samples + id);
 
             float4 data0 = __ldg(ptr + 0);
             float4 data1 = __ldg(ptr + 1);
@@ -142,8 +142,7 @@ void trace_samples() {
             ray.z = data1.y;
 
             if (!(float_as_uint(data1.z) & 0x0100)) {
-                node_task = make_uint2(0, 0);
-                triangle_task = make_uint2(0, 0);
+                return;
             }
 
             inv_ray.x = 1.0f / (fabsf(ray.x) > eps ? ray.x : copysignf(eps, ray.x));

--- a/Luminary/lib/cuda/bvh.cuh
+++ b/Luminary/lib/cuda/bvh.cuh
@@ -391,7 +391,7 @@ void trace_samples() {
             const int active_threads = __popc(__activemask());
 
             while (triangle_task.y != 0) {
-                const int threshold = active_threads * 0.4f;
+                const int threshold = active_threads * 0.2f;
                 const int triangle_threads = __popc(__activemask());
 
                 if (triangle_threads < threshold) {
@@ -415,11 +415,11 @@ void trace_samples() {
                 if (packed_stptr_invoct.x > 0) {
                     STACK_POP(node_task);
                 } else {
-                    float4 write_back;
+                    float2 write_back;
                     write_back.x = depth;
                     write_back.y = uint_as_float(hit_id);
 
-                    __stwt(ptr + 4, write_back);
+                    __stcs((float2*)(ptr + 4) + 1, write_back);
                     break;
                 }
             }

--- a/Luminary/lib/cuda/kernels.cuh
+++ b/Luminary/lib/cuda/kernels.cuh
@@ -154,7 +154,7 @@ float get_light_angle(Light light, vec3 pos) {
     return fminf(PI/2.0f,asinf(light.radius / d));
 }
 
-__global__
+__global__ __launch_bounds__(THREADS_PER_BLOCK)
 void shade_samples() {
   unsigned int id = threadIdx.x + blockIdx.x * blockDim.x;
 
@@ -549,10 +549,6 @@ void finalize_samples() {
       device_frame[pixel_index] = pixel;
 
       if (device_denoiser) {
-        RGBF temporal_albedo = device_frame[pixel_index];
-        albedo.r = (albedo.r / device_diffuse_samples + temporal_albedo.r * device_temporal_frames) / (device_temporal_frames + 1);
-        albedo.g = (albedo.g / device_diffuse_samples + temporal_albedo.g * device_temporal_frames) / (device_temporal_frames + 1);
-        albedo.b = (albedo.b / device_diffuse_samples + temporal_albedo.b * device_temporal_frames) / (device_temporal_frames + 1);
         device_albedo_buffer[pixel_index] = albedo;
       }
 

--- a/Luminary/lib/cuda/kernels.cuh
+++ b/Luminary/lib/cuda/kernels.cuh
@@ -1,0 +1,569 @@
+#ifndef CU_KERNELS_H
+#define CU_KERNELS_H
+
+#include "scene.h"
+#include "primitives.h"
+#include "image.h"
+#include "raytrace.h"
+#include "mesh.h"
+#include "SDL/SDL.h"
+#include "cuda/utils.cuh"
+#include "cuda/math.cuh"
+#include "cuda/sky.cuh"
+#include "cuda/brdf.cuh"
+#include "cuda/bvh.cuh"
+#include "cuda/directives.cuh"
+#include "cuda/random.cuh"
+#include <cuda_runtime_api.h>
+#include <optix.h>
+#include <optix_stubs.h>
+#include <float.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <time.h>
+#include <chrono>
+#include <thread>
+#include <immintrin.h>
+
+__global__
+void initialize_samples() {
+  unsigned int id = threadIdx.x + blockIdx.x * blockDim.x;
+
+  Sample sample;
+  sample.state.y = 0;
+  sample.state.z = 0;
+
+  RGBF pixel;
+  pixel.r = 0.0f;
+  pixel.g = 0.0f;
+  pixel.b = 0.0f;
+
+  while (id < device_samples_length && id < device_diffuse_samples * device_amount) {
+    device_samples[id] = sample;
+    id += blockDim.x * gridDim.x;
+  }
+}
+
+__global__
+void generate_samples() {
+  unsigned int id = threadIdx.x + blockIdx.x * blockDim.x;
+
+  Sample sample;
+
+  while (id < device_samples_length && id < device_diffuse_samples * device_amount) {
+    int sample_index;
+
+    while (1) {
+      if (id >= device_samples_length || id >= device_diffuse_samples * device_amount) return;
+      sample = device_samples[id];
+      sample_index = id + sample.state.z * device_samples_length;
+      if (!(sample.state.y & 0b1) && sample_index < device_diffuse_samples * device_amount) break;
+      id += blockDim.x * gridDim.x;
+    }
+
+    vec3 default_ray;
+
+    const unsigned int pixel_index = sample_index / device_diffuse_samples;
+
+    const int x = pixel_index % device_width;
+    const int y = pixel_index / device_width;
+
+    const int random_index = device_temporal_frames + (((device_sample_offset + id) * 3) << 10);
+
+    default_ray.x = device_scene.camera.focal_length * (-device_scene.camera.fov + device_step * x + device_offset_x * sample_blue_noise(x,y,random_index,8) * 2.0f);
+    default_ray.y = device_scene.camera.focal_length * (device_vfov - device_step * y - device_offset_y * sample_blue_noise(x,y,random_index,9) * 2.0f);
+    default_ray.z = -device_scene.camera.focal_length;
+
+    const float alpha = sample_blue_noise(x, y, random_index, 0) * 2.0f * PI;
+    const float beta  = sample_blue_noise(x, y, random_index, 1) * device_scene.camera.aperture_size;
+
+    vec3 point_on_aperture;
+    point_on_aperture.x = cosf(alpha) * beta;
+    point_on_aperture.y = sinf(alpha) * beta;
+    point_on_aperture.z = 0.0f;
+
+    default_ray = vec_diff(default_ray, point_on_aperture);
+    point_on_aperture = rotate_vector_by_quaternion(point_on_aperture, device_camera_rotation);
+
+    sample.ray = normalize_vector(rotate_vector_by_quaternion(default_ray, device_camera_rotation));
+    sample.origin.x = device_scene.camera.pos.x + point_on_aperture.x;
+    sample.origin.y = device_scene.camera.pos.y + point_on_aperture.y;
+    sample.origin.z = device_scene.camera.pos.z + point_on_aperture.z;
+    sample.index.x = x;
+    sample.index.y = y;
+    sample.random_index = random_index;
+    sample.state.x = 0;
+    sample.state.y = 0b11;
+    sample.state.z++;
+    sample.record.r = 1.0f;
+    sample.record.g = 1.0f;
+    sample.record.b = 1.0f;
+    sample.result.r = 0.0f;
+    sample.result.g = 0.0f;
+    sample.result.b = 0.0f;
+
+    device_samples[id] = sample;
+
+    id += blockDim.x * gridDim.x;
+  }
+}
+
+__global__
+void trace_samples() {
+  unsigned int id = threadIdx.x + blockIdx.x * blockDim.x;
+
+  while (id < device_samples_length && id < device_diffuse_samples * device_amount) {
+    float4* ptr = (float4*)(device_samples + id);
+
+    float4 data0 = __ldg(ptr + 0);
+    float4 data1 = __ldg(ptr + 1);
+
+    if (!(float_as_uint(data1.z) & 0x0000ff00)) {
+      id += blockDim.x * gridDim.x;
+      continue;
+    }
+
+    vec3 origin;
+    origin.x = data0.x;
+    origin.y = data0.y;
+    origin.z = data0.z;
+
+    vec3 ray;
+    ray.x = data0.w;
+    ray.y = data1.x;
+    ray.z = data1.y;
+
+    traversal_result result = traverse_bvh(origin, ray, device_scene.nodes, device_scene.traversal_triangles);
+
+    float4 write_back;
+    write_back.x = result.depth;
+    write_back.y = uint_as_float(result.hit_id);
+
+    __stwt(ptr + 4, write_back);
+
+    id += blockDim.x * gridDim.x;
+  }
+}
+
+__device__
+int write_albedo_buffer(RGBF value, Sample sample) {
+  if (device_denoiser && sample.state.y & 0b10) {
+    const int buffer_index = sample.index.x + sample.index.y * device_width;
+    atomicAdd((float*)(device_albedo_buffer + buffer_index) + 0, value.r / device_diffuse_samples);
+    atomicAdd((float*)(device_albedo_buffer + buffer_index) + 1, value.g / device_diffuse_samples);
+    atomicAdd((float*)(device_albedo_buffer + buffer_index) + 2, value.b / device_diffuse_samples);
+  }
+
+  return sample.state.y & 0b01;
+}
+
+__device__
+int write_albedo_buffer(RGBAF value, Sample sample) {
+  if (device_denoiser && sample.state.y & 0b10) {
+    const int buffer_index = sample.index.x + sample.index.y * device_width;
+    atomicAdd((float*)(device_albedo_buffer + buffer_index) + 0, value.r / device_diffuse_samples);
+    atomicAdd((float*)(device_albedo_buffer + buffer_index) + 1, value.g / device_diffuse_samples);
+    atomicAdd((float*)(device_albedo_buffer + buffer_index) + 2, value.b / device_diffuse_samples);
+  }
+
+  return sample.state.y & 0b01;
+}
+
+__device__
+Sample write_result(Sample sample) {
+  sample.state.y &= 0b10;
+  atomicAdd((uint32_t*)&device_sample_offset, 1);
+
+  if (isnan(sample.result.r) || isinf(sample.result.r)) {
+    sample.result.r = 0.0f;
+  }
+  if (isnan(sample.result.g) || isinf(sample.result.g)) {
+    sample.result.g = 0.0f;
+  }
+  if (isnan(sample.result.b) || isinf(sample.result.b)) {
+    sample.result.b = 0.0f;
+  }
+
+  const int buffer_index = sample.index.x + sample.index.y * device_width;
+
+  atomicAdd((float*)(device_internal_frame + buffer_index) + 0, sample.result.r / device_diffuse_samples);
+  atomicAdd((float*)(device_internal_frame + buffer_index) + 1, sample.result.g / device_diffuse_samples);
+  atomicAdd((float*)(device_internal_frame + buffer_index) + 2, sample.result.b / device_diffuse_samples);
+
+  return sample;
+}
+
+__device__
+float get_light_angle(Light light, vec3 pos) {
+    const float d = get_length(vec_diff(pos, light.pos)) + eps;
+    return fminf(PI/2.0f,asinf(light.radius / d));
+}
+
+__global__
+void shade_samples(volatile uint32_t* progress) {
+  unsigned int id = threadIdx.x + blockIdx.x * blockDim.x;
+
+  while (id < device_samples_length && id < device_diffuse_samples * device_amount) {
+    Sample sample = device_samples[id];
+
+    if (!(sample.state.y & 0b1)) {
+      id += blockDim.x * gridDim.x;
+      continue;
+    }
+
+    if (sample.hit_id == 0xffffffff) {
+      RGBF sky = get_sky_color(sample.ray);
+
+      sample.state.y = write_albedo_buffer(sky, sample);
+
+      sample.result.r += sky.r * sample.record.r;
+      sample.result.g += sky.g * sample.record.g;
+      sample.result.b += sky.b * sample.record.b;
+
+      device_samples[id] = write_result(sample);
+      id += blockDim.x * gridDim.x;
+      continue;
+    }
+
+    sample.origin.x += sample.ray.x * sample.depth;
+    sample.origin.y += sample.ray.y * sample.depth;
+    sample.origin.z += sample.ray.z * sample.depth;
+
+    const float4* hit_address = (float4*)(device_scene.triangles + sample.hit_id);
+
+    const float4 t1 = __ldg(hit_address);
+    const float4 t2 = __ldg(hit_address + 1);
+    const float4 t3 = __ldg(hit_address + 2);
+    const float4 t4 = __ldg(hit_address + 3);
+    const float4 t5 = __ldg(hit_address + 4);
+    const float4 t6 = __ldg(hit_address + 5);
+    const float4 t7 = __ldg(hit_address + 6);
+
+    vec3 vertex;
+    vertex.x = t1.x;
+    vertex.y = t1.y;
+    vertex.z = t1.z;
+
+    vec3 edge1;
+    edge1.x = t1.w;
+    edge1.y = t2.x;
+    edge1.z = t2.y;
+
+    vec3 edge2;
+    edge2.x = t2.z;
+    edge2.y = t2.w;
+    edge2.z = t3.x;
+
+    vec3 normal = get_coordinates_in_triangle(vertex, edge1, edge2, sample.origin);
+
+    const float lambda = normal.x;
+    const float mu = normal.y;
+
+    vec3 vertex_normal;
+    vertex_normal.x = t3.y;
+    vertex_normal.y = t3.z;
+    vertex_normal.z = t3.w;
+
+    vec3 edge1_normal;
+    edge1_normal.x = t4.x;
+    edge1_normal.y = t4.y;
+    edge1_normal.z = t4.z;
+
+    vec3 edge2_normal;
+    edge2_normal.x = t4.w;
+    edge2_normal.y = t5.x;
+    edge2_normal.z = t5.y;
+
+    normal = lerp_normals(vertex_normal, edge1_normal, edge2_normal, lambda, mu);
+
+    UV vertex_texture;
+    vertex_texture.u = t5.z;
+    vertex_texture.v = t5.w;
+
+    UV edge1_texture;
+    edge1_texture.u = t6.x;
+    edge1_texture.v = t6.y;
+
+    UV edge2_texture;
+    edge2_texture.u = t6.z;
+    edge2_texture.v = t6.w;
+
+    const UV tex_coords = lerp_uv(vertex_texture, edge1_texture, edge2_texture, lambda, mu);
+
+    vec3 face_normal;
+    face_normal.x = t7.x;
+    face_normal.y = t7.y;
+    face_normal.z = t7.z;
+
+    const int texture_object = __float_as_int(t7.w);
+
+    const ushort4 maps = __ldg((ushort4*)(device_texture_assignments + texture_object));
+
+    float roughness;
+    float metallic;
+    float intensity;
+
+    if (maps.z) {
+        const float4 material_f = tex2D<float4>(device_material_atlas[maps.z], tex_coords.u, 1.0f - tex_coords.v);
+
+        roughness = (1.0f - material_f.x) * (1.0f - material_f.x);
+        metallic = material_f.y;
+        intensity = material_f.z * 255.0f;
+    } else {
+        roughness = 0.81f;
+        metallic = 0.0f;
+        intensity = 1.0f;
+    }
+
+    if (maps.y) {
+        #ifdef LIGHTS_AT_NIGHT_ONLY
+        if (device_sun.y < NIGHT_THRESHOLD) {
+        #endif
+        const float4 illuminance_f = tex2D<float4>(device_illuminance_atlas[maps.y], tex_coords.u, 1.0f - tex_coords.v);
+
+        RGBF emission;
+        emission.r = illuminance_f.x;
+        emission.g = illuminance_f.y;
+        emission.b = illuminance_f.z;
+
+        sample.state.y = write_albedo_buffer(emission, sample);
+
+        sample.result.r += emission.r * intensity * sample.record.r;
+        sample.result.g += emission.g * intensity * sample.record.g;
+        sample.result.b += emission.b * intensity * sample.record.b;
+
+        #ifdef FIRST_LIGHT_ONLY
+        const double max_result = fmaxf(sample.result.r, fmaxf(sample.result.g, sample.result.b));
+        if (max_result > eps) {
+            device_samples[id] = write_result(sample);
+            id += blockDim.x * gridDim.x;
+            continue;
+        }
+        #endif
+
+        #ifdef LIGHTS_AT_NIGHT_ONLY
+        }
+        #endif
+    }
+
+    RGBAF albedo;
+
+    if (maps.x) {
+        const float4 albedo_f = tex2D<float4>(device_albedo_atlas[maps.x], tex_coords.u, 1.0f - tex_coords.v);
+        albedo.r = albedo_f.x;
+        albedo.g = albedo_f.y;
+        albedo.b = albedo_f.z;
+        albedo.a = albedo_f.w;
+    } else {
+        albedo.r = 0.9f;
+        albedo.g = 0.9f;
+        albedo.b = 0.9f;
+        albedo.a = 1.0f;
+    }
+
+    sample.state.y = write_albedo_buffer(albedo, sample);
+
+    if (sample_blue_noise(sample.index.x, sample.index.y, sample.random_index, 40) > albedo.a) {
+      sample.origin.x += 2.0f * eps * sample.ray.x;
+      sample.origin.y += 2.0f * eps * sample.ray.y;
+      sample.origin.z += 2.0f * eps * sample.ray.z;
+    } else {
+        const float specular_probability = lerp(0.5f, 1.0f - eps, metallic);
+
+        if (dot_product(normal, face_normal) < 0.0f) {
+            face_normal = scale_vector(face_normal, -1.0f);
+        }
+
+        const vec3 V = scale_vector(sample.ray, -1.0f);
+
+        if (dot_product(face_normal, V) < 0.0f) {
+            normal = scale_vector(normal, -1.0f);
+            face_normal = scale_vector(face_normal, -1.0f);
+        }
+
+        sample.origin.x += face_normal.x * (eps * 8.0f);
+        sample.origin.y += face_normal.y * (eps * 8.0f);
+        sample.origin.z += face_normal.z * (eps * 8.0f);
+
+        const float light_sample = sample_blue_noise(sample.index.x, sample.index.y, sample.random_index, 50);
+
+        float light_angle;
+        vec3 light_source;
+        #ifdef LIGHTS_AT_NIGHT_ONLY
+        const int light_count = (device_sun.y < NIGHT_THRESHOLD) ? device_scene.lights_length - 1 : 1;
+        #else
+        const int light_count = device_scene.lights_length;
+        #endif
+
+        const float light_sample_probability = 1.0f - 1.0f/(light_count + 1);
+
+        if (light_sample < light_sample_probability) {
+            #ifdef LIGHTS_AT_NIGHT_ONLY
+                const uint32_t light = (device_sun.y < NIGHT_THRESHOLD && light_count > 0) ? 1 + (uint32_t)(sample_blue_noise(sample.index.x, sample.index.y, sample.random_index, 51) * light_count) : 0;
+            #else
+                const uint32_t light = (uint32_t)(sample_blue_noise(sample.index.x, sample.index.y, sample.random_index, 51) * light_count);
+            #endif
+
+            const float4 light_data = __ldg((float4*)(device_scene.lights + light));
+            vec3 light_pos;
+            light_pos.x = light_data.x;
+            light_pos.y = light_data.y;
+            light_pos.z = light_data.z;
+            light_pos = vec_diff(light_pos, sample.origin);
+            light_source = normalize_vector(light_pos);
+            const float d = get_length(light_pos) + eps;
+            light_angle = fminf(PI/2.0f,asinf(light_data.w / d)) * 2.0f / PI;
+        }
+
+        if (sample_blue_noise(sample.index.x, sample.index.y, sample.random_index, 10) < specular_probability) {
+            const float alpha = roughness * roughness;
+
+            const float beta = sample_blue_noise(sample.index.x, sample.index.y, sample.random_index, 2);
+            const float gamma = 2.0f * 3.1415926535f * sample_blue_noise(sample.index.x, sample.index.y, sample.random_index, 3);
+
+            const Quaternion rotation_to_z = get_rotation_to_z_canonical(normal);
+
+            float weight = 1.0f;
+
+            const vec3 V_local = rotate_vector_by_quaternion(V, rotation_to_z);
+            vec3 H_local;
+
+            if (alpha < eps) {
+                H_local.x = 0.0f;
+                H_local.y = 0.0f;
+                H_local.z = 1.0f;
+            } else {
+                const vec3 S_local = rotate_vector_by_quaternion(
+                    normalize_vector(sample_ray_from_angles_and_vector(beta * light_angle, gamma, light_source)),
+                    rotation_to_z);
+
+                if (light_sample < light_sample_probability && S_local.z > 0.0f) {
+                    H_local.x = S_local.x + V_local.x;
+                    H_local.y = S_local.y + V_local.y;
+                    H_local.z = S_local.z + V_local.z;
+
+                    H_local = normalize_vector(H_local);
+
+                    weight = (1.0f/light_sample_probability) * light_angle * light_count;
+                } else {
+                    H_local = sample_GGX_VNDF(V_local, alpha, sample_blue_noise(sample.index.x, sample.index.y, sample.random_index, 4), sample_blue_noise(sample.index.x, sample.index.y, sample.random_index, 5));
+
+                    if (S_local.z > 0.0f) weight = (1.0f/(1.0f-light_sample_probability));
+                }
+            }
+
+            const vec3 ray_local = reflect_vector(scale_vector(V_local, -1.0f), H_local);
+
+            const float HdotR = fmaxf(eps, fminf(1.0f, dot_product(H_local, ray_local)));
+            const float NdotR = fmaxf(eps, fminf(1.0f, ray_local.z));
+            const float NdotV = fmaxf(eps, fminf(1.0f, V_local.z));
+
+            sample.ray = normalize_vector(rotate_vector_by_quaternion(ray_local, inverse_quaternion(rotation_to_z)));
+
+            vec3 specular_f0;
+            specular_f0.x = lerp(0.04f, albedo.r, metallic);
+            specular_f0.y = lerp(0.04f, albedo.g, metallic);
+            specular_f0.z = lerp(0.04f, albedo.b, metallic);
+
+            const vec3 F = Fresnel_Schlick(specular_f0, shadowed_F90(specular_f0), HdotR);
+
+            const float milchs_energy_recovery = lerp(1.0f, 1.51f + 1.51f * NdotV, roughness);
+
+            weight *= milchs_energy_recovery * Smith_G2_over_G1_height_correlated(alpha * alpha, NdotR, NdotV) / specular_probability;
+
+            sample.record.r *= F.x * weight;
+            sample.record.g *= F.y * weight;
+            sample.record.b *= F.z * weight;
+        }
+        else
+        {
+            float weight = 1.0f;
+
+            const float alpha = acosf(sqrtf(sample_blue_noise(sample.index.x, sample.index.y, sample.random_index, 2)));
+            const float gamma = 2.0f * PI * sample_blue_noise(sample.index.x, sample.index.y, sample.random_index, 3);
+
+            sample.ray = normalize_vector(sample_ray_from_angles_and_vector(alpha * light_angle, gamma, light_source));
+            const float light_feasible = dot_product(sample.ray, normal);
+
+            if (light_sample < light_sample_probability && light_feasible >= 0.0f) {
+                weight = (1.0f/light_sample_probability) * light_angle * light_count;
+            } else {
+                sample.ray = sample_ray_from_angles_and_vector(alpha, gamma, normal);
+
+                if (light_feasible >=0.0f) weight = (1.0f/(1.0f-light_sample_probability));
+            }
+
+            vec3 H;
+            H.x = V.x + sample.ray.x;
+            H.y = V.y + sample.ray.y;
+            H.z = V.z + sample.ray.z;
+            H = normalize_vector(H);
+
+            const float half_angle = fmaxf(eps, fminf(dot_product(H, sample.ray),1.0f));
+            const float energyFactor = lerp(1.0f, 1.0f/1.51f, roughness);
+
+            const float FD90MinusOne = 0.5f * roughness + 2.0f * half_angle * half_angle * roughness - 1.0f;
+
+            const float angle = fmaxf(eps, fminf(dot_product(normal, sample.ray),1.0f));
+            const float previous_angle = fmaxf(eps, fminf(dot_product(V, normal),1.0f));
+
+            const float FDL = 1.0f + (FD90MinusOne * __powf(1.0f - angle, 5.0f));
+            const float FDV = 1.0f + (FD90MinusOne * __powf(1.0f - previous_angle, 5.0f));
+
+            weight *= FDL * FDV * energyFactor * (1.0f - metallic) / (1.0f - specular_probability);
+
+            sample.record.r *= albedo.r * weight;
+            sample.record.g *= albedo.g * weight;
+            sample.record.b *= albedo.b * weight;
+        }
+    }
+
+    #ifdef WEIGHT_BASED_EXIT
+    const double max_record = fmaxf(sample.record.r, fmaxf(sample.record.g, sample.record.b));
+    if (max_record < CUTOFF ||
+    (max_record < PROBABILISTIC_CUTOFF && sample_blue_noise(sample.index.x, sample.index.y, sample.random_index, 20) > (max_record - CUTOFF)/(CUTOFF-PROBABILISTIC_CUTOFF)))
+    {
+      sample.state.x = device_reflection_depth;
+    }
+    #endif
+
+    #ifdef LOW_QUALITY_LONG_BOUNCES
+    if (sample.state.x >= MIN_BOUNCES && sample_blue_noise(sample.index.x, sample.index.y, sample.random_index, 21) < 1.0f/device_reflection_depth) {
+      sample.state.x = device_reflection_depth;
+    }
+    #endif
+
+    sample.random_index++;
+    sample.state.x++;
+
+    if (sample.state.x >= device_reflection_depth) {
+      sample = write_result(sample);
+    }
+
+    device_samples[id] = sample;
+
+    id += blockDim.x * gridDim.x;
+  }
+}
+
+__global__
+void finalize_samples() {
+  unsigned int id = threadIdx.x + blockIdx.x * blockDim.x;
+
+  while (id < device_amount) {
+    RGBF new_pixel = device_internal_frame[id];
+    RGBF old_pixel = device_frame[id];
+
+    new_pixel.r = (new_pixel.r + old_pixel.r * device_temporal_frames) / (device_temporal_frames + 1);
+    new_pixel.g = (new_pixel.g + old_pixel.g * device_temporal_frames) / (device_temporal_frames + 1);
+    new_pixel.b = (new_pixel.b + old_pixel.b * device_temporal_frames) / (device_temporal_frames + 1);
+
+    device_frame[id] = new_pixel;
+
+    id += blockDim.x * gridDim.x;
+  }
+}
+
+
+#endif /* CU_KERNELS_H */

--- a/Luminary/lib/cuda/kernels.cuh
+++ b/Luminary/lib/cuda/kernels.cuh
@@ -525,7 +525,7 @@ void finalize_samples() {
     sample_offset++;
 
     if (sample_offset == device_samples_per_sample) {
-      const float weight = 1.0f/device_diffuse_samples;
+      const float weight = device_scene.camera.exposure/device_diffuse_samples;
 
       RGBF temporal_pixel = device_frame[pixel_index];
       pixel.r = (pixel.r * weight + temporal_pixel.r * device_temporal_frames) / (device_temporal_frames + 1);

--- a/Luminary/lib/cuda/kernels.cuh
+++ b/Luminary/lib/cuda/kernels.cuh
@@ -369,11 +369,11 @@ void shade_samples() {
             light_angle = fminf(PI/2.0f,asinf(light_data.w / d)) * 2.0f / PI;
         }
 
+        const float gamma = 2.0f * PI * sample_blue_noise(sample.index.x, sample.index.y, sample.random_index, 3);
+        const float beta = sample_blue_noise(sample.index.x, sample.index.y, sample.random_index, 2);
+
         if (sample_blue_noise(sample.index.x, sample.index.y, sample.random_index, 10) < specular_probability) {
             const float alpha = roughness * roughness;
-
-            const float beta = sample_blue_noise(sample.index.x, sample.index.y, sample.random_index, 2);
-            const float gamma = 2.0f * 3.1415926535f * sample_blue_noise(sample.index.x, sample.index.y, sample.random_index, 3);
 
             const Quaternion rotation_to_z = get_rotation_to_z_canonical(normal);
 
@@ -433,8 +433,7 @@ void shade_samples() {
         {
             float weight = 1.0f;
 
-            const float alpha = acosf(sqrtf(sample_blue_noise(sample.index.x, sample.index.y, sample.random_index, 2)));
-            const float gamma = 2.0f * PI * sample_blue_noise(sample.index.x, sample.index.y, sample.random_index, 3);
+            const float alpha = acosf(sqrtf(beta));
 
             sample.ray = normalize_vector(sample_ray_from_angles_and_vector(alpha * light_angle, gamma, light_source));
             const float light_feasible = dot_product(sample.ray, normal);

--- a/Luminary/lib/cuda/kernels.cuh
+++ b/Luminary/lib/cuda/kernels.cuh
@@ -58,7 +58,7 @@ void generate_samples() {
   unsigned int id = threadIdx.x + blockIdx.x * blockDim.x;
 
   int pixel_index = id;
-  id *= device_diffuse_samples;
+  id *= device_samples_per_sample;
   int sample_offset = 0;
   int iterations_for_pixel = device_diffuse_samples;
 
@@ -507,7 +507,7 @@ void finalize_samples() {
   unsigned int id = threadIdx.x + blockIdx.x * blockDim.x;
 
   int pixel_index = id;
-  id *= device_diffuse_samples;
+  id *= device_samples_per_sample;
   int sample_offset = 0;
 
   RGBF pixel;

--- a/Luminary/lib/cuda/kernels.cuh
+++ b/Luminary/lib/cuda/kernels.cuh
@@ -366,7 +366,7 @@ void shade_samples() {
             light_pos = vec_diff(light_pos, sample.origin);
             light_source = normalize_vector(light_pos);
             const float d = get_length(light_pos) + eps;
-            light_angle = fminf(PI/2.0f,asinf(light_data.w / d)) * 2.0f / PI;
+            light_angle = fminf(1.0f,asinf(light_data.w / d) * 2.0f / PI);
         }
 
         const float gamma = 2.0f * PI * sample_blue_noise(sample.index.x, sample.index.y, sample.random_index, 3);
@@ -400,7 +400,7 @@ void shade_samples() {
 
                     weight = (1.0f/light_sample_probability) * light_angle * light_count;
                 } else {
-                    H_local = sample_GGX_VNDF(V_local, alpha, sample_blue_noise(sample.index.x, sample.index.y, sample.random_index, 4), sample_blue_noise(sample.index.x, sample.index.y, sample.random_index, 5));
+                    H_local = sample_GGX_VNDF(V_local, alpha, beta, gamma);
 
                     if (S_local.z > 0.0f) weight = (1.0f/(1.0f-light_sample_probability));
                 }

--- a/Luminary/lib/cuda/kernels.cuh
+++ b/Luminary/lib/cuda/kernels.cuh
@@ -159,8 +159,6 @@ void shade_samples() {
   unsigned int id = threadIdx.x + blockIdx.x * blockDim.x;
 
   while (id < device_samples_length) {
-    Sample sample;
-
     while (1) {
       if (id >= device_samples_length) return;
       unsigned short state = __ldcs((unsigned short*)(device_samples + id) + 12);

--- a/Luminary/lib/cuda/math.cuh
+++ b/Luminary/lib/cuda/math.cuh
@@ -64,11 +64,15 @@ float get_length(const vec3 vector) {
     return sqrtf(vector.x * vector.x + vector.y * vector.y + vector.z * vector.z);
 }
 
-__device__ __host__
+__device__
 vec3 normalize_vector(vec3 vector) {
-    const float inv_length = 1.0f / get_length(vector);
+    const float scale = rnorm3df(vector.x, vector.y, vector.z);
 
-    return scale_vector(vector, inv_length);
+    vector.x *= scale;
+    vector.y *= scale;
+    vector.z *= scale;
+
+    return vector;
 }
 
 __device__

--- a/Luminary/lib/cuda/random.cuh
+++ b/Luminary/lib/cuda/random.cuh
@@ -28,15 +28,13 @@ float sample_blue_noise(int x, int y, int sample_index, int sample_dimension) {
 	sample_index = sample_index & 255;
   sample_dimension = sample_dimension & 255;
 
-  int ranking_index = sample_dimension + (x + y * 128) * 8;
+  const int ranking_index = (sample_dimension + (x + y * 128) * 8) & 131071;
 
-  if (ranking_index >= 128 * 128 * 8) ranking_index -= 128 * 128 * 8;
+	const int ranked_sample_index = sample_index ^ __ldg(ranking_tile + ranking_index);
 
-	const int ranked_sample_index = sample_index ^ ranking_tile[ranking_index];
+	int value = __ldg(sobol_256spp_256d + sample_dimension + ranked_sample_index * 256);
 
-	int value = sobol_256spp_256d[sample_dimension + ranked_sample_index * 256];
-
-	value = value ^ scrambling_tile[(sample_dimension % 8) + (x + y * 128) * 8];
+	value = value ^ __ldg(scrambling_tile + (sample_dimension % 8) + (x + y * 128) * 8);
 
 	return (0.5f + value) / 256.0f;
 }

--- a/Luminary/lib/cuda/sky.cuh
+++ b/Luminary/lib/cuda/sky.cuh
@@ -82,8 +82,8 @@ RGBF get_sky_color(const vec3 ray) {
     const float sun_intensity = 6.0f;
 
     sun_color.r = 1.0f * sun_intensity;
-    sun_color.g = 0.9f * sun_intensity;
-    sun_color.b = 0.8f * sun_intensity;
+    sun_color.g = 1.0f * sun_intensity;
+    sun_color.b = 1.0f * sun_intensity;
 
     const vec3 sun_normalized = device_sun;
     const vec3 sun = scale_vector(sun_normalized, sun_dist);

--- a/Luminary/lib/cuda/utils.cuh
+++ b/Luminary/lib/cuda/utils.cuh
@@ -49,7 +49,7 @@ struct Quaternion {
 struct Sample {
   vec3 origin;
   vec3 ray;
-  uchar4 state; //x = depth, y = 1st bit (active?) 2nd bit (albedo buffer written?), z = positional counter
+  ushort2 state; //x = (high 8bits) 1st bit (active?) 2nd bit (albedo buffer written?) | (low 8 bits) depth, y = iterations left
   int random_index;
   RGBF record;
   RGBF result;
@@ -74,6 +74,9 @@ unsigned int device_samples_length;
 
 __constant__
 Sample* device_samples;
+
+__constant__
+int device_iterations_per_sample;
 
 __device__
 unsigned int device_sample_offset;

--- a/Luminary/lib/cuda/utils.cuh
+++ b/Luminary/lib/cuda/utils.cuh
@@ -52,7 +52,7 @@ struct Quaternion {
 struct Sample {
   vec3 origin;
   vec3 ray;
-  ushort2 state; //x = (high 8bits) 1st bit (active?) 2nd bit (albedo buffer written?) | (low 8 bits) depth, y = iterations left
+  ushort2 state; //x = (high 8bits) 1st bit (active?) 2nd bit (albedo buffer written?) other 6bits give sample offset | (low 8 bits) depth, y = iterations left
   int random_index;
   RGBF record;
   RGBF result;
@@ -76,7 +76,10 @@ __constant__
 unsigned int device_samples_length;
 
 __constant__
-Sample* device_samples;
+Sample* device_active_samples;
+
+__constant__
+Sample* device_finished_samples;
 
 __constant__
 int device_iterations_per_sample;
@@ -85,7 +88,7 @@ __constant__
 int device_samples_per_sample;
 
 __device__
-unsigned int device_sample_offset;
+int device_sample_offset;
 
 __constant__
 int device_temporal_frames;

--- a/Luminary/lib/cuda/utils.cuh
+++ b/Luminary/lib/cuda/utils.cuh
@@ -46,6 +46,19 @@ struct Quaternion {
 } typedef Quaternion;
 #endif
 
+struct Sample {
+  vec3 origin;
+  vec3 ray;
+  uchar4 state; //x = depth, y = 1st bit (active?) 2nd bit (albedo buffer written?), z = positional counter
+  int random_index;
+  RGBF record;
+  RGBF result;
+  uint2 index;
+  float depth;
+  unsigned int hit_id;
+  uint2 padding;
+} typedef Sample;
+
 //===========================================================================================
 // Device Variables
 //===========================================================================================
@@ -55,6 +68,18 @@ int device_reflection_depth;
 
 __constant__
 Scene device_scene;
+
+__constant__
+unsigned int device_samples_length;
+
+__constant__
+Sample* device_samples;
+
+__device__
+unsigned int device_sample_offset;
+
+__constant__
+int device_temporal_frames;
 
 __constant__
 int device_diffuse_samples;
@@ -67,6 +92,9 @@ RGBF* device_denoiser;
 
 __constant__
 RGBF* device_albedo_buffer;
+
+__constant__
+RGBF* device_internal_frame;
 
 __constant__
 unsigned int device_width;

--- a/Luminary/lib/cuda/utils.cuh
+++ b/Luminary/lib/cuda/utils.cuh
@@ -6,6 +6,9 @@
 #include <cuda_runtime_api.h>
 #include "utils.h"
 
+#define THREADS_PER_BLOCK 128
+#define BLOCKS_PER_GRID 512
+
 #define gpuErrchk(ans) { gpuAssert((ans), __FILE__, __LINE__); }
 inline void gpuAssert(cudaError_t code, const char *file, int line, bool abort=true)
 {

--- a/Luminary/lib/cuda/utils.cuh
+++ b/Luminary/lib/cuda/utils.cuh
@@ -53,10 +53,10 @@ struct Sample {
   int random_index;
   RGBF record;
   RGBF result;
-  uint2 index;
+  RGBF albedo_buffer;
+  ushort2 index;
   float depth;
   unsigned int hit_id;
-  uint2 padding;
 } typedef Sample;
 
 //===========================================================================================

--- a/Luminary/lib/cuda/utils.cuh
+++ b/Luminary/lib/cuda/utils.cuh
@@ -78,6 +78,9 @@ Sample* device_samples;
 __constant__
 int device_iterations_per_sample;
 
+__constant__
+int device_samples_per_sample;
+
 __device__
 unsigned int device_sample_offset;
 

--- a/Luminary/lib/output.c
+++ b/Luminary/lib/output.c
@@ -131,7 +131,7 @@ void realtime_output(Scene scene, raytrace_instance* instance, const int filters
     const double frame_time = 1000.0 * ((double) (clock() - time)) / CLOCKS_PER_SEC;
     time                    = clock();
 
-    sprintf(title, "Luminary - FPS: %.1f - FPS: %.0fms", 1000.0 / frame_time, frame_time);
+    sprintf(title, "Luminary - FPS: %.1f - Frametime: %.0fms", 1000.0 / frame_time, frame_time);
 
     const double normalized_time = frame_time / 16.66667;
 

--- a/Luminary/lib/output.c
+++ b/Luminary/lib/output.c
@@ -149,6 +149,10 @@ void realtime_output(Scene scene, raytrace_instance* instance, const int filters
         else if (keystate[SDL_SCANCODE_G]) {
           instance->scene_gpu.camera.aperture_size += 0.001f * event.motion.xrel;
         }
+        else if (keystate[SDL_SCANCODE_E]) {
+          instance->scene_gpu.camera.exposure +=
+            max(1.0f, instance->scene_gpu.camera.exposure) * 0.005f * event.motion.xrel;
+        }
         else {
           instance->scene_gpu.camera.rotation.y += event.motion.xrel * (-0.005f);
           instance->scene_gpu.camera.rotation.x += event.motion.yrel * (-0.005f);
@@ -228,6 +232,9 @@ void realtime_output(Scene scene, raytrace_instance* instance, const int filters
 
     if (instance->scene_gpu.camera.focal_length < 0.0f)
       instance->scene_gpu.camera.focal_length = 0.0f;
+
+    if (instance->scene_gpu.camera.exposure < 0.0f)
+      instance->scene_gpu.camera.exposure = 0.0f;
 
     const float movement_speed = 0.5f * shift_pressed * normalized_time;
 

--- a/Luminary/lib/raytrace.cu
+++ b/Luminary/lib/raytrace.cu
@@ -24,11 +24,6 @@
 #include <thread>
 #include <immintrin.h>
 
-const static int threads_per_block = 128;
-const static int blocks_per_grid = 512;
-
-
-
 //---------------------------------
 // Path Tracing
 //---------------------------------
@@ -279,13 +274,13 @@ extern "C" void trace_scene(Scene scene, raytrace_instance* instance, const int 
         gpuErrchk(cudaMemset(instance->albedo_buffer_gpu, 0, sizeof(RGBF) * instance->width * instance->height));
     }
 
-    generate_samples<<<blocks_per_grid,threads_per_block>>>();
+    generate_samples<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>();
     gpuErrchk(cudaDeviceSynchronize());
 
     while (curr_progress > 0) {
-        trace_samples<<<blocks_per_grid,threads_per_block>>>();
+        trace_samples<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>();
         gpuErrchk(cudaDeviceSynchronize());
-        shade_samples<<<blocks_per_grid,threads_per_block>>>();
+        shade_samples<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>();
         gpuErrchk(cudaDeviceSynchronize());
         gpuErrchk(cudaPeekAtLastError());
         gpuErrchk(cudaMemcpyFromSymbol(&curr_progress, device_sample_offset, sizeof(unsigned int), 0, cudaMemcpyDeviceToHost));
@@ -302,7 +297,7 @@ extern "C" void trace_scene(Scene scene, raytrace_instance* instance, const int 
     }
 
     printf("\r                                                                                                              \r");
-    finalize_samples<<<blocks_per_grid,threads_per_block>>>();
+    finalize_samples<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>();
     gpuErrchk(cudaDeviceSynchronize());
 }
 
@@ -384,7 +379,7 @@ extern "C" void free_realtime(raytrace_instance* instance) {
 }
 
 extern "C" void copy_framebuffer_to_8bit(RGB8* buffer, RGBF* source, raytrace_instance* instance) {
-    convert_RGBF_to_RGB8<<<blocks_per_grid,threads_per_block>>>(source);
+    convert_RGBF_to_RGB8<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>(source);
     gpuErrchk(cudaMemcpy(buffer, instance->buffer_8bit_gpu, sizeof(RGB8) * instance->width * instance->height, cudaMemcpyDeviceToHost));
 }
 

--- a/Luminary/lib/raytrace.cu
+++ b/Luminary/lib/raytrace.cu
@@ -11,6 +11,7 @@
 #include "cuda/bvh.cuh"
 #include "cuda/directives.cuh"
 #include "cuda/random.cuh"
+#include "cuda/kernels.cuh"
 #include <cuda_runtime_api.h>
 #include <optix.h>
 #include <optix_stubs.h>
@@ -26,518 +27,11 @@
 const static int threads_per_block = 128;
 const static int blocks_per_grid = 512;
 
-struct Sample {
-    vec3 origin;
-    vec3 ray;
-    RGBF record;
-    RGBF result;
-    short2 state; //x = depth, y = 1st bit (finished?) 2nd bit (albedo buffer written?)
-    ushort2 index;
-    int random_index;
-} typedef Sample;
+
 
 //---------------------------------
 // Path Tracing
 //---------------------------------
-
-__device__
-float get_light_angle(Light light, vec3 pos) {
-    const float d = get_length(vec_diff(pos, light.pos)) + eps;
-    return fminf(PI/2.0f,asinf(light.radius / d));
-}
-
-__device__
-Sample trace_ray_iterative(const Sample input_sample) {
-    int albedo_buffer_written = input_sample.state.y & 0b10;
-    const ushort2 index = input_sample.index;
-    int random_index = input_sample.random_index;
-
-    RGBF result = input_sample.result;
-    RGBF record = input_sample.record;
-
-    vec3 ray = input_sample.ray;
-    vec3 origin = input_sample.origin;
-
-    short2 state = input_sample.state;
-    const int starting_threads = __popc(__activemask());
-
-    for (; state.x < device_reflection_depth; state.x++) {
-        traversal_result traversal = traverse_bvh(origin, ray, device_scene.nodes, device_scene.traversal_triangles);
-
-        if (traversal.hit_id == 0xffffffff) {
-            RGBF sky = get_sky_color(ray);
-
-            if (device_denoiser && !albedo_buffer_written) {
-                RGBF sum = device_albedo_buffer[index.x + index.y * device_width];
-                sum.r += sky.r;
-                sum.g += sky.g;
-                sum.b += sky.b;
-                device_albedo_buffer[index.x + index.y * device_width] = sum;
-
-                albedo_buffer_written++;
-                state.y |= 0b10;
-            }
-
-            result.r += sky.r * record.r;
-            result.g += sky.g * record.g;
-            result.b += sky.b * record.b;
-
-            state.y |= 0b1;
-
-            break;
-        }
-
-        vec3 curr;
-        curr.x = origin.x + ray.x * traversal.depth;
-        curr.y = origin.y + ray.y * traversal.depth;
-        curr.z = origin.z + ray.z * traversal.depth;
-
-        const float4* hit_address = (float4*)(device_scene.triangles + traversal.hit_id);
-
-        const float4 t1 = __ldg(hit_address);
-        const float4 t2 = __ldg(hit_address + 1);
-        const float4 t3 = __ldg(hit_address + 2);
-        const float4 t4 = __ldg(hit_address + 3);
-        const float4 t5 = __ldg(hit_address + 4);
-        const float4 t6 = __ldg(hit_address + 5);
-        const float4 t7 = __ldg(hit_address + 6);
-
-        vec3 vertex;
-        vertex.x = t1.x;
-        vertex.y = t1.y;
-        vertex.z = t1.z;
-
-        vec3 edge1;
-        edge1.x = t1.w;
-        edge1.y = t2.x;
-        edge1.z = t2.y;
-
-        vec3 edge2;
-        edge2.x = t2.z;
-        edge2.y = t2.w;
-        edge2.z = t3.x;
-
-        vec3 normal = get_coordinates_in_triangle(vertex, edge1, edge2, curr);
-
-        const float lambda = normal.x;
-        const float mu = normal.y;
-
-        vec3 vertex_normal;
-        vertex_normal.x = t3.y;
-        vertex_normal.y = t3.z;
-        vertex_normal.z = t3.w;
-
-        vec3 edge1_normal;
-        edge1_normal.x = t4.x;
-        edge1_normal.y = t4.y;
-        edge1_normal.z = t4.z;
-
-        vec3 edge2_normal;
-        edge2_normal.x = t4.w;
-        edge2_normal.y = t5.x;
-        edge2_normal.z = t5.y;
-
-        normal = lerp_normals(vertex_normal, edge1_normal, edge2_normal, lambda, mu);
-
-        UV vertex_texture;
-        vertex_texture.u = t5.z;
-        vertex_texture.v = t5.w;
-
-        UV edge1_texture;
-        edge1_texture.u = t6.x;
-        edge1_texture.v = t6.y;
-
-        UV edge2_texture;
-        edge2_texture.u = t6.z;
-        edge2_texture.v = t6.w;
-
-        const UV tex_coords = lerp_uv(vertex_texture, edge1_texture, edge2_texture, lambda, mu);
-
-        vec3 face_normal;
-        face_normal.x = t7.x;
-        face_normal.y = t7.y;
-        face_normal.z = t7.z;
-
-        const int texture_object = __float_as_int(t7.w);
-
-        const ushort4 maps = __ldg((ushort4*)(device_texture_assignments + texture_object));
-
-        float roughness;
-        float metallic;
-        float intensity;
-
-        if (maps.z) {
-            const float4 material_f = tex2D<float4>(device_material_atlas[maps.z], tex_coords.u, 1.0f - tex_coords.v);
-
-            roughness = (1.0f - material_f.x) * (1.0f - material_f.x);
-            metallic = material_f.y;
-            intensity = material_f.z * 255.0f;
-        } else {
-            roughness = 0.81f;
-            metallic = 0.0f;
-            intensity = 1.0f;
-        }
-
-        if (maps.y) {
-            #ifdef LIGHTS_AT_NIGHT_ONLY
-            if (device_sun.y < NIGHT_THRESHOLD) {
-            #endif
-            const float4 illuminance_f = tex2D<float4>(device_illuminance_atlas[maps.y], tex_coords.u, 1.0f - tex_coords.v);
-
-            RGBF emission;
-            emission.r = illuminance_f.x;
-            emission.g = illuminance_f.y;
-            emission.b = illuminance_f.z;
-
-            result.r += emission.r * intensity * record.r;
-            result.g += emission.g * intensity * record.g;
-            result.b += emission.b * intensity * record.b;
-
-            #ifdef FIRST_LIGHT_ONLY
-            const double max_result = fmaxf(result.r, fmaxf(result.g, result.b));
-            if (max_result > eps) {
-                state.y |= 0b1;
-                break;
-            }
-            #endif
-
-            #ifdef LIGHTS_AT_NIGHT_ONLY
-            }
-            #endif
-        }
-
-        RGBAF albedo;
-
-        if (maps.x) {
-            const float4 albedo_f = tex2D<float4>(device_albedo_atlas[maps.x], tex_coords.u, 1.0f - tex_coords.v);
-            albedo.r = albedo_f.x;
-            albedo.g = albedo_f.y;
-            albedo.b = albedo_f.z;
-            albedo.a = albedo_f.w;
-        } else {
-            albedo.r = 0.9f;
-            albedo.g = 0.9f;
-            albedo.b = 0.9f;
-            albedo.a = 1.0f;
-        }
-
-        if (sample_blue_noise(index.x, index.y, random_index, 40) > albedo.a) {
-            origin.x = curr.x + 2.0f * eps * ray.x;
-            origin.y = curr.y + 2.0f * eps * ray.y;
-            origin.z = curr.z + 2.0f * eps * ray.z;
-        } else {
-            if (device_denoiser && !albedo_buffer_written) {
-                RGBF sum = device_albedo_buffer[index.x + index.y * device_width];
-                sum.r += albedo.r;
-                sum.g += albedo.g;
-                sum.b += albedo.b;
-                device_albedo_buffer[index.x + index.y * device_width] = sum;
-
-                albedo_buffer_written++;
-                state.y |= 0b10;
-            }
-
-            const float specular_probability = lerp(0.5f, 1.0f - eps, metallic);
-
-            if (dot_product(normal, face_normal) < 0.0f) {
-                face_normal = scale_vector(face_normal, -1.0f);
-            }
-
-            const vec3 V = scale_vector(ray, -1.0f);
-
-            if (dot_product(face_normal, V) < 0.0f) {
-                normal = scale_vector(normal, -1.0f);
-                face_normal = scale_vector(face_normal, -1.0f);
-            }
-
-            origin.x = curr.x + face_normal.x * (eps * 8.0f);
-            origin.y = curr.y + face_normal.y * (eps * 8.0f);
-            origin.z = curr.z + face_normal.z * (eps * 8.0f);
-
-            const float light_sample = sample_blue_noise(index.x, index.y, random_index, 50);
-
-            float light_angle;
-            vec3 light_source;
-            #ifdef LIGHTS_AT_NIGHT_ONLY
-            const int light_count = (device_sun.y < NIGHT_THRESHOLD) ? device_scene.lights_length - 1 : 1;
-            #else
-            const int light_count = device_scene.lights_length;
-            #endif
-
-            const float light_sample_probability = 1.0f - 1.0f/(light_count + 1);
-
-
-            if (light_sample < light_sample_probability) {
-                #ifdef LIGHTS_AT_NIGHT_ONLY
-                    const uint32_t light = (device_sun.y < NIGHT_THRESHOLD && light_count > 0) ? 1 + (uint32_t)(sample_blue_noise(index.x, index.y, random_index, 51) * light_count) : 0;
-                #else
-                    const uint32_t light = (uint32_t)(sample_blue_noise(index.x, index.y, random_index, 51) * light_count);
-                #endif
-
-                const float4 light_data = __ldg((float4*)(device_scene.lights + light));
-                vec3 light_pos;
-                light_pos.x = light_data.x;
-                light_pos.y = light_data.y;
-                light_pos.z = light_data.z;
-                light_pos = vec_diff(light_pos, origin);
-                light_source = normalize_vector(light_pos);
-                const float d = get_length(light_pos) + eps;
-                light_angle = fminf(PI/2.0f,asinf(light_data.w / d)) * 2.0f / PI;
-            }
-
-            if (sample_blue_noise(index.x, index.y, random_index, 10) < specular_probability) {
-                const float alpha = roughness * roughness;
-
-                const float beta = sample_blue_noise(index.x, index.y, random_index, 2);
-                const float gamma = 2.0f * 3.1415926535f * sample_blue_noise(index.x, index.y, random_index, 3);
-
-                const Quaternion rotation_to_z = get_rotation_to_z_canonical(normal);
-
-                float weight = 1.0f;
-
-                const vec3 V_local = rotate_vector_by_quaternion(V, rotation_to_z);
-                vec3 H_local;
-
-                if (alpha < eps) {
-                    H_local.x = 0.0f;
-                    H_local.y = 0.0f;
-                    H_local.z = 1.0f;
-                } else {
-                    const vec3 S_local = rotate_vector_by_quaternion(
-                        normalize_vector(sample_ray_from_angles_and_vector(beta * light_angle, gamma, light_source)),
-                        rotation_to_z);
-
-                    if (light_sample < light_sample_probability && S_local.z > 0.0f) {
-                        H_local.x = S_local.x + V_local.x;
-                        H_local.y = S_local.y + V_local.y;
-                        H_local.z = S_local.z + V_local.z;
-
-                        H_local = normalize_vector(H_local);
-
-                        weight = (1.0f/light_sample_probability) * light_angle * light_count;
-                    } else {
-                        H_local = sample_GGX_VNDF(V_local, alpha, sample_blue_noise(index.x, index.y, random_index, 4), sample_blue_noise(index.x, index.y, random_index, 5));
-
-                        if (S_local.z > 0.0f) weight = (1.0f/(1.0f-light_sample_probability));
-                    }
-                }
-
-                const vec3 ray_local = reflect_vector(scale_vector(V_local, -1.0f), H_local);
-
-                const float HdotR = fmaxf(eps, fminf(1.0f, dot_product(H_local, ray_local)));
-                const float NdotR = fmaxf(eps, fminf(1.0f, ray_local.z));
-                const float NdotV = fmaxf(eps, fminf(1.0f, V_local.z));
-
-                ray = normalize_vector(rotate_vector_by_quaternion(ray_local, inverse_quaternion(rotation_to_z)));
-
-                vec3 specular_f0;
-                specular_f0.x = lerp(0.04f, albedo.r, metallic);
-                specular_f0.y = lerp(0.04f, albedo.g, metallic);
-                specular_f0.z = lerp(0.04f, albedo.b, metallic);
-
-                const vec3 F = Fresnel_Schlick(specular_f0, shadowed_F90(specular_f0), HdotR);
-
-                const float milchs_energy_recovery = lerp(1.0f, 1.51f + 1.51f * NdotV, roughness);
-
-                weight *= milchs_energy_recovery * Smith_G2_over_G1_height_correlated(alpha * alpha, NdotR, NdotV) / specular_probability;
-
-                record.r *= F.x * weight;
-                record.g *= F.y * weight;
-                record.b *= F.z * weight;
-            }
-            else
-            {
-                float weight = 1.0f;
-
-                const float alpha = acosf(sqrtf(sample_blue_noise(index.x, index.y, random_index, 2)));
-                const float gamma = 2.0f * PI * sample_blue_noise(index.x, index.y, random_index, 3);
-
-                ray = normalize_vector(sample_ray_from_angles_and_vector(alpha * light_angle, gamma, light_source));
-                const float light_feasible = dot_product(ray, normal);
-
-                if (light_sample < light_sample_probability && light_feasible >= 0.0f) {
-                    weight = (1.0f/light_sample_probability) * light_angle * light_count;
-                } else {
-                    ray = sample_ray_from_angles_and_vector(alpha, gamma, normal);
-
-                    if (light_feasible >=0.0f) weight = (1.0f/(1.0f-light_sample_probability));
-                }
-
-                vec3 H;
-                H.x = V.x + ray.x;
-                H.y = V.y + ray.y;
-                H.z = V.z + ray.z;
-                H = normalize_vector(H);
-
-                const float half_angle = fmaxf(eps, fminf(dot_product(H,ray),1.0f));
-                const float energyFactor = lerp(1.0f, 1.0f/1.51f, roughness);
-
-                const float FD90MinusOne = 0.5f * roughness + 2.0f * half_angle * half_angle * roughness - 1.0f;
-
-                const float angle = fmaxf(eps, fminf(dot_product(normal, ray),1.0f));
-                const float previous_angle = fmaxf(eps, fminf(dot_product(V, normal),1.0f));
-
-                const float FDL = 1.0f + (FD90MinusOne * __powf(1.0f - angle, 5.0f));
-                const float FDV = 1.0f + (FD90MinusOne * __powf(1.0f - previous_angle, 5.0f));
-
-                weight *= FDL * FDV * energyFactor * (1.0f - metallic) / (1.0f - specular_probability);
-
-                record.r *= albedo.r * weight;
-                record.g *= albedo.g * weight;
-                record.b *= albedo.b * weight;
-            }
-        }
-
-        #ifdef WEIGHT_BASED_EXIT
-        const double max_record = fmaxf(record.r, fmaxf(record.g, record.b));
-        if (max_record < CUTOFF ||
-        (max_record < PROBABILISTIC_CUTOFF && sample_blue_noise(index.x, index.y, random_index, 20) > (max_record - CUTOFF)/(CUTOFF-PROBABILISTIC_CUTOFF)))
-        {
-            state.y |= 0b1;
-            break;
-        }
-        #endif
-
-        #ifdef LOW_QUALITY_LONG_BOUNCES
-        if (state.x >= MIN_BOUNCES && sample_blue_noise(index.x, index.y, random_index, 21) < 1.0f/device_reflection_depth) {
-            state.y |= 0b1;
-            break;
-        }
-        #endif
-
-        if (__popc(__activemask()) < 0.1f *  starting_threads) break;
-
-        random_index++;
-    }
-
-    if (state.x >= device_reflection_depth - 1) state.y |= 0b1;
-
-    Sample output_sample;
-    output_sample.origin = origin;
-    output_sample.ray = ray;
-    output_sample.result = result;
-    output_sample.record = record;
-    output_sample.state = state;
-    output_sample.index = index;
-    output_sample.random_index = random_index + 1;
-
-    return output_sample;
-}
-
-__global__
-void trace_rays(volatile uint32_t* progress, const int temporal_frames) {
-    unsigned int id = threadIdx.x + blockIdx.x * blockDim.x;
-
-    Sample sample;
-    sample.state.y = 0b11;
-    int i = 0;
-
-    RGBF pixel;
-    pixel.r = 0.0f;
-    pixel.g = 0.0f;
-    pixel.b = 0.0f;
-
-    while (id < device_amount) {
-        if (sample.state.y & 0b1) {
-            vec3 ray;
-            vec3 default_ray;
-
-            const int x = (id / 1) % device_width;
-            const int y = (id % 1) + 1 * (id / (1 * device_width));
-
-            const int random_index = temporal_frames + ((id * 3) << 10);
-
-            default_ray.x = device_scene.camera.focal_length * (-device_scene.camera.fov + device_step * x + device_offset_x * sample_blue_noise(x,y,random_index,8) * 2.0f);
-            default_ray.y = device_scene.camera.focal_length * (device_vfov - device_step * y - device_offset_y * sample_blue_noise(x,y,random_index,9) * 2.0f);
-            default_ray.z = -device_scene.camera.focal_length;
-
-            const float alpha = sample_blue_noise(x,y,random_index,0) * 2.0f * PI;
-            const float beta  = sample_blue_noise(x,y,random_index,1) * device_scene.camera.aperture_size;
-
-            vec3 point_on_aperture;
-            point_on_aperture.x = cosf(alpha) * beta;
-            point_on_aperture.y = sinf(alpha) * beta;
-            point_on_aperture.z = 0.0f;
-
-            default_ray = vec_diff(default_ray, point_on_aperture);
-            ray = normalize_vector(rotate_vector_by_quaternion(default_ray, device_camera_rotation));
-            point_on_aperture = rotate_vector_by_quaternion(point_on_aperture, device_camera_rotation);
-
-            sample.ray = ray;
-            sample.origin.x = device_scene.camera.pos.x + point_on_aperture.x;
-            sample.origin.y = device_scene.camera.pos.y + point_on_aperture.y;
-            sample.origin.z = device_scene.camera.pos.z + point_on_aperture.z;
-            sample.index.x = x;
-            sample.index.y = y;
-            sample.random_index = random_index;
-            sample.state.x = 0;
-            sample.state.y = 0;
-            sample.record.r = 1.0f;
-            sample.record.g = 1.0f;
-            sample.record.b = 1.0f;
-            sample.result.r = 0.0f;
-            sample.result.g = 0.0f;
-            sample.result.b = 0.0f;
-        }
-
-        sample = trace_ray_iterative(sample);
-
-        if (sample.state.y & 0b1) {
-            if (isnan(sample.result.r) || isinf(sample.result.r)) {
-                sample.result.r = 1.0f;
-            }
-            if (isnan(sample.result.g) || isinf(sample.result.g)) {
-                sample.result.g = 0.0f;
-            }
-            if (isnan(sample.result.b) || isinf(sample.result.b)) {
-                sample.result.b = 0.0f;
-            }
-
-            pixel.r += sample.result.r;
-            pixel.g += sample.result.g;
-            pixel.b += sample.result.b;
-
-            i++;
-        }
-
-        if (i == device_diffuse_samples) {
-            const float weight = 1.0f/(float)device_diffuse_samples;
-
-            pixel.r *= weight;
-            pixel.g *= weight;
-            pixel.b *= weight;
-
-            const int buffer_index = sample.index.x + sample.index.y * device_width;
-
-            if (device_denoiser) {
-                RGBF sum = device_albedo_buffer[buffer_index];
-                sum.r *= weight;
-                sum.g *= weight;
-                sum.b *= weight;
-                device_albedo_buffer[buffer_index] = sum;
-            }
-
-            if (temporal_frames) {
-                RGBF temporal_pixel = device_frame[buffer_index];
-                pixel.r = (pixel.r + temporal_pixel.r * temporal_frames) / (temporal_frames + 1);
-                pixel.g = (pixel.g + temporal_pixel.g * temporal_frames) / (temporal_frames + 1);
-                pixel.b = (pixel.b + temporal_pixel.b * temporal_frames) / (temporal_frames + 1);
-            }
-
-            device_frame[buffer_index] = pixel;
-
-            id += blockDim.x * gridDim.x;
-            i = 0;
-
-            pixel.r = 0.0f;
-            pixel.g = 0.0f;
-            pixel.b = 0.0f;
-
-            atomicAdd((uint32_t*)progress, 1);
-            __threadfence_system();
-        }
-    }
-}
 
 static void update_sun(const Scene scene) {
     vec3 sun;
@@ -612,6 +106,27 @@ extern "C" raytrace_instance* init_raytracing(
 
     instance->scene_gpu = scene;
 
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, 0);
+    size_t samples_length = prop.totalGlobalMem;
+    samples_length -= sizeof(texture_assignment) * scene.materials_length;
+    samples_length -= sizeof(Triangle) * instance->scene_gpu.triangles_length;
+    samples_length -= sizeof(Traversal_Triangle) * instance->scene_gpu.triangles_length;
+    samples_length -= sizeof(Node8) * instance->scene_gpu.nodes_length;
+    samples_length -= sizeof(Light) * instance->scene_gpu.lights_length;
+    samples_length -= sizeof(RGBF) * width * height;
+    samples_length /= 4;
+    samples_length /= sizeof(Sample);
+
+    const unsigned int actual_samples_length = (unsigned int)samples_length;
+
+    printf("A: %zu B: %d\n", samples_length, actual_samples_length);
+    printf("SAMPLE_SIZE: %zu\n", sizeof(Sample));
+
+    gpuErrchk(cudaMalloc((void**) &(instance->samples_gpu), sizeof(Sample) * samples_length));
+    gpuErrchk(cudaMemcpyToSymbol(device_samples, &(instance->samples_gpu), sizeof(void*), 0, cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpyToSymbol(device_samples_length, &(actual_samples_length), sizeof(unsigned int), 0, cudaMemcpyHostToDevice));
+
     gpuErrchk(cudaMalloc((void**) &(instance->scene_gpu.texture_assignments), sizeof(texture_assignment) * scene.materials_length));
     gpuErrchk(cudaMalloc((void**) &(instance->scene_gpu.triangles), sizeof(Triangle) * instance->scene_gpu.triangles_length));
     gpuErrchk(cudaMalloc((void**) &(instance->scene_gpu.traversal_triangles), sizeof(Traversal_Triangle) * instance->scene_gpu.triangles_length));
@@ -634,6 +149,10 @@ extern "C" raytrace_instance* init_raytracing(
     gpuErrchk(cudaMemcpyToSymbol(device_illuminance_atlas, &(instance->illuminance_atlas), sizeof(cudaTextureObject_t), 0, cudaMemcpyHostToDevice));
     gpuErrchk(cudaMemcpyToSymbol(device_material_atlas, &(instance->material_atlas), sizeof(cudaTextureObject_t), 0, cudaMemcpyHostToDevice));
     gpuErrchk(cudaMemcpyToSymbol(device_amount, &(amount), sizeof(unsigned int), 0, cudaMemcpyHostToDevice));
+
+    gpuErrchk(cudaMalloc((void**) &(instance->internal_frame_buffer_gpu), sizeof(RGBF) * width * height));
+    gpuErrchk(cudaMemcpyToSymbol(device_internal_frame, &(instance->internal_frame_buffer_gpu), sizeof(void*), 0, cudaMemcpyHostToDevice));
+
 
     instance->denoiser = denoiser;
 
@@ -734,39 +253,53 @@ extern "C" void trace_scene(Scene scene, raytrace_instance* instance, const int 
     gpuErrchk(cudaHostGetDevicePointer((uint32_t**)&progress_gpu, (uint32_t*)progress_cpu, 0));
     *progress_cpu = 0;
 
+    const int zero = 0;
+
+    gpuErrchk(cudaMemcpyToSymbol(device_sample_offset, &(zero), sizeof(unsigned int), 0, cudaMemcpyHostToDevice));
     gpuErrchk(cudaMemcpyToSymbol(device_scene, &(instance->scene_gpu), sizeof(Scene), 0, cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpyToSymbol(device_temporal_frames, &(temporal_frames), sizeof(unsigned int), 0, cudaMemcpyHostToDevice));
 
     update_sun(instance->scene_gpu);
     update_camera_pos(instance->scene_gpu, instance->width, instance->height);
 
     clock_t t = clock();
 
-    trace_rays<<<blocks_per_grid,threads_per_block>>>(progress_gpu, temporal_frames);
+    uint32_t curr_progress = 0;
+    const uint32_t total_samples = instance->width * instance->height * instance->diffuse_samples;
 
-    if (progress == 1) {
-        gpuErrchk(cudaEventRecord(kernelFinished));
+    gpuErrchk(cudaDeviceSynchronize());
+    gpuErrchk(cudaMemset(instance->internal_frame_buffer_gpu, 0, sizeof(RGBF) * instance->width * instance->height));
+    if (instance->denoiser) {
+        gpuErrchk(cudaMemset(instance->albedo_buffer_gpu, 0, sizeof(RGBF) * instance->width * instance->height));
+    }
+    initialize_samples<<<blocks_per_grid,threads_per_block>>>();
+    gpuErrchk(cudaDeviceSynchronize());
 
-        uint32_t progress = 0;
-        const uint32_t total_pixels = instance->width * instance->height;
-        const float ratio = 1.0f/((float)instance->width * (float)instance->height);
-        while (cudaEventQuery(kernelFinished) != cudaSuccess) {
-            std::this_thread::sleep_for(std::chrono::microseconds(100000));
-            gpuErrchk(cudaPeekAtLastError());
-            uint32_t new_progress = *progress_cpu;
-            if (new_progress > progress) {
-                progress = new_progress;
-            }
+    while (curr_progress < total_samples) {
+        generate_samples<<<blocks_per_grid,threads_per_block>>>();
+        gpuErrchk(cudaDeviceSynchronize());
+        trace_samples<<<blocks_per_grid,threads_per_block>>>();
+        gpuErrchk(cudaDeviceSynchronize());
+        shade_samples<<<blocks_per_grid,threads_per_block>>>(progress_gpu);
+        gpuErrchk(cudaDeviceSynchronize());
+        gpuErrchk(cudaPeekAtLastError());
+        gpuErrchk(cudaMemcpyFromSymbol(&curr_progress, device_sample_offset, sizeof(unsigned int), 0, cudaMemcpyDeviceToHost));
+
+        if (progress == 1) {
+            const uint32_t total_pixels = instance->width * instance->height;
+            const float ratio = 1.0f/((float)instance->width * (float)instance->height);
             clock_t curr_time = clock();
             const double time_elapsed = (((double)curr_time - t)/CLOCKS_PER_SEC);
             printf("\r                                                                                                          \rProgress: %2.1f%% - Time Elapsed: %.1fs - Time Remaining: %.1fs - Performance: %.1f Mrays/s",
-                (float)progress * ratio * 100, time_elapsed,
-                (total_pixels - progress) * (time_elapsed/progress),
-                0.000001 * instance->diffuse_samples * instance->reflection_depth * progress / time_elapsed);
-        }
+                (float)curr_progress * ratio * 100, time_elapsed,
+                (total_pixels - curr_progress) * (time_elapsed/curr_progress),
+                0.000001 * instance->diffuse_samples * instance->reflection_depth * curr_progress / time_elapsed);
 
-        printf("\r                                                                                                              \r");
+            printf("\r                                                                                                              \r");
+        }
     }
 
+    finalize_samples<<<blocks_per_grid,threads_per_block>>>();
     gpuErrchk(cudaDeviceSynchronize());
 }
 
@@ -776,6 +309,8 @@ extern "C" void free_inputs(raytrace_instance* instance) {
     gpuErrchk(cudaFree(instance->scene_gpu.traversal_triangles));
     gpuErrchk(cudaFree(instance->scene_gpu.nodes));
     gpuErrchk(cudaFree(instance->scene_gpu.lights));
+    gpuErrchk(cudaFree(instance->samples_gpu));
+    gpuErrchk(cudaFree(instance->internal_frame_buffer_gpu));
 }
 
 extern "C" void free_outputs(raytrace_instance* instance) {

--- a/Luminary/lib/raytrace.cu
+++ b/Luminary/lib/raytrace.cu
@@ -145,7 +145,7 @@ extern "C" raytrace_instance* init_raytracing(
     gpuErrchk(cudaMemcpyToSymbol(device_samples_per_sample, &(instance->samples_per_sample), sizeof(int), 0, cudaMemcpyHostToDevice));
     samples_length = width * height * instance->samples_per_sample;
     unsigned int temp = (instance->diffuse_samples + instance->samples_per_sample - 1)/instance->samples_per_sample;
-    gpuErrchk(cudaMemcpyToSymbol(device_samples_per_sample, &(temp ), sizeof(int), 0, cudaMemcpyHostToDevice));
+    gpuErrchk(cudaMemcpyToSymbol(device_iterations_per_sample, &(temp), sizeof(int), 0, cudaMemcpyHostToDevice));
 
     const unsigned int actual_samples_length = (unsigned int)samples_length;
 

--- a/Luminary/lib/raytrace.cu
+++ b/Luminary/lib/raytrace.cu
@@ -271,8 +271,7 @@ extern "C" void trace_scene(Scene scene, raytrace_instance* instance, const int 
     clock_t t = clock();
 
     uint32_t curr_progress = total_iterations;
-    const uint32_t total_samples = instance->width * instance->height * instance->diffuse_samples;
-    const float ratio = 1.0f/(total_samples);
+    const float ratio = 1.0f/(total_iterations);
 
     gpuErrchk(cudaDeviceSynchronize());
     gpuErrchk(cudaMemset(instance->internal_frame_buffer_gpu, 0, sizeof(RGBF) * instance->width * instance->height));
@@ -293,11 +292,12 @@ extern "C" void trace_scene(Scene scene, raytrace_instance* instance, const int 
 
         if (progress == 1) {
             clock_t curr_time = clock();
+            const int samples_done = total_iterations - curr_progress;
             const double time_elapsed = (((double)curr_time - t)/CLOCKS_PER_SEC);
             printf("\r                                                                                                          \rProgress: %2.1f%% - Time Elapsed: %.1fs - Time Remaining: %.1fs - Performance: %.1f Mrays/s",
-                (float)curr_progress * ratio * 100, time_elapsed,
-                (total_samples - curr_progress) * (time_elapsed/curr_progress),
-                0.000001 * instance->reflection_depth * curr_progress / time_elapsed);
+                (float)samples_done * ratio * 100, time_elapsed,
+                (total_iterations - samples_done) * (time_elapsed/samples_done),
+                0.000001 * instance->reflection_depth * (float)(instance->diffuse_samples)/(instance->iterations_per_sample) * samples_done / time_elapsed);
         }
     }
 

--- a/Luminary/lib/raytrace.cu
+++ b/Luminary/lib/raytrace.cu
@@ -120,9 +120,12 @@ extern "C" raytrace_instance* init_raytracing(
 
     instance->iterations_per_sample = (unsigned int)samples_length / (width * height);
     instance->iterations_per_sample = (instance->iterations_per_sample > instance->diffuse_samples) ? instance->diffuse_samples : instance->iterations_per_sample;
+    gpuErrchk(cudaMemcpyToSymbol(device_samples_per_sample, &(instance->iterations_per_sample), sizeof(int), 0, cudaMemcpyHostToDevice));
     samples_length = width * height * instance->iterations_per_sample;
-    printf("L: %zu\n",samples_length);
-    gpuErrchk(cudaMemcpyToSymbol(device_iterations_per_sample, &(instance->iterations_per_sample), sizeof(int), 0, cudaMemcpyHostToDevice));
+    printf("SAMPLES_PER_SAMPLE: %d\n",instance->iterations_per_sample);
+    unsigned int temp = (instance->diffuse_samples + instance->iterations_per_sample - 1)/instance->iterations_per_sample;
+    gpuErrchk(cudaMemcpyToSymbol(device_iterations_per_sample, &(temp ), sizeof(int), 0, cudaMemcpyHostToDevice));
+    printf("ITERATIONS_PER_SAMPLE: %d\n",temp);
 
     const unsigned int actual_samples_length = (unsigned int)samples_length;
 

--- a/Luminary/lib/scene.c
+++ b/Luminary/lib/scene.c
@@ -90,6 +90,7 @@ Scene load_scene(const char* filename, raytrace_instance** instance, char** outp
   scene.camera.fov           = 1.0f;
   scene.camera.focal_length  = 1.0f;
   scene.camera.aperture_size = 0.00f;
+  scene.camera.exposure      = 1.0f;
 
   int width           = 1280;
   int height          = 720;

--- a/Luminary/lib/utils.h
+++ b/Luminary/lib/utils.h
@@ -62,6 +62,7 @@ struct raytrace_instance {
   Scene scene_gpu;
   int denoiser;
   void* samples_gpu;
+  int iterations_per_sample;
   RGBF* albedo_buffer_gpu;
 } typedef raytrace_instance;
 

--- a/Luminary/lib/utils.h
+++ b/Luminary/lib/utils.h
@@ -20,6 +20,7 @@ struct Camera {
   float fov;
   float focal_length;
   float aperture_size;
+  float exposure;
 } typedef Camera;
 
 struct Light {

--- a/Luminary/lib/utils.h
+++ b/Luminary/lib/utils.h
@@ -51,7 +51,6 @@ struct raytrace_instance {
   RGBF* frame_buffer;
   RGBF* frame_buffer_gpu;
   RGB8* buffer_8bit_gpu;
-  RGBF* internal_frame_buffer_gpu;
   void* albedo_atlas;
   int albedo_atlas_length;
   void* illuminance_atlas;
@@ -63,7 +62,8 @@ struct raytrace_instance {
   Scene scene_gpu;
   int denoiser;
   void* samples_gpu;
-  int iterations_per_sample;
+  void* samples_finished_gpu;
+  int samples_per_sample;
   RGBF* albedo_buffer_gpu;
 } typedef raytrace_instance;
 

--- a/Luminary/lib/utils.h
+++ b/Luminary/lib/utils.h
@@ -50,6 +50,7 @@ struct raytrace_instance {
   RGBF* frame_buffer;
   RGBF* frame_buffer_gpu;
   RGB8* buffer_8bit_gpu;
+  RGBF* internal_frame_buffer_gpu;
   void* albedo_atlas;
   int albedo_atlas_length;
   void* illuminance_atlas;
@@ -60,6 +61,7 @@ struct raytrace_instance {
   int diffuse_samples;
   Scene scene_gpu;
   int denoiser;
+  void* samples_gpu;
   RGBF* albedo_buffer_gpu;
 } typedef raytrace_instance;
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Luminary is a CUDA based Pathtracing renderer.
 
 This project is for fun and to learn more about `Computer Graphics`. There is no end goal, I will add whatever I feel like. The following is a list of things that I may do in the future.
 
+- Implement faster and higher quality binary BVH construction.
 - Implement Clouds.
 - Implement volumetric lighting.
 - Implement refraction.
-- Implement better Importance Sampling.
 
 As a denoiser I use `Optix` since any non machine learning denoiser is quite frankly not all that great and machine learning is out of the scope of this project.
 
@@ -92,7 +92,7 @@ Alternatively you can run Luminary in `Realtime Mode` using
 START "" Luminary.exe Scenes/Example.lum r
 ```
 
-You can control the camera through `WASD` and the mouse. The sun can be rotated with the arrow keys. The focal length can be changed by pressing `F` and moving the mouse horizontally. The aperture size can be changed similarly through `G`.
+You can control the camera through `WASD` and the mouse. The sun can be rotated with the arrow keys. The focal length can be changed by pressing `F` and moving the mouse horizontally. The aperture size can be changed similarly through `G`. The exposure is adjustable in a similar way through `E`.
 
 Note that bad performance is to be expected. Path tracing is very computationally expensive, `Luminary` is not very performant yet and `Luminary` does not make use of `RT-Cores` found on `Turing` or `Ampere` architecture graphics cards. The latter would be considered if they would be exposed through `CUDA`.
 


### PR DESCRIPTION
This splits the mega kernel into multiple kernels.

This adds some overhead both computationally aswell as memory wise. However, performance in offline rendering is equal and up to 50% higher in realtime mode (the difference here being that the realtime mode typically runs at 1 sample per pixel while offline rendering will use many samples per pixel). Further this adds exposure sliders for realtime mode and fixes the blue noise seeding when using more than 1 sample.