### PR TITLE
Spatial splits

### DIFF
--- a/Luminary/lib/bvh.c
+++ b/Luminary/lib/bvh.c
@@ -10,9 +10,9 @@
 #include <immintrin.h>
 
 #define THRESHOLD_TRIANGLES 3
-#define OBJECT_SPLIT_BIN_COUNT 64
-#define SPATIAL_SPLIT_THRESHOLD 0.0001f
-#define SPATIAL_SPLIT_BIN_COUNT 64
+#define OBJECT_SPLIT_BIN_COUNT 32
+#define SPATIAL_SPLIT_THRESHOLD 0.00001f
+#define SPATIAL_SPLIT_BIN_COUNT 32
 #define COST_OF_TRIANGLE 0.4f
 #define COST_OF_NODE 1.0f
 
@@ -503,8 +503,6 @@ Node2* build_bvh_structure(
       optimal_method = 0;
 
       for (int a = 0; a < 3; a++) {
-        // quick_sort_fragments(fragments + fragments_ptr, node.triangle_count, a);
-
         float low_split;
         const float interval =
           construct_bins(bins, fragments + fragments_ptr, node.triangle_count, a, &low_split);
@@ -671,7 +669,7 @@ Node2* build_bvh_structure(
         fragments_buffer_count += duplicated_triangles;
 
         for (int k = 0; k < leaf_node_count; k++) {
-          if (nodes[leaf_nodes[k]].triangles_address > fragments_ptr)
+          if (nodes[leaf_nodes[k]].triangles_address > buffer_ptr)
             nodes[leaf_nodes[k]].triangles_address += duplicated_triangles;
         }
 

--- a/Luminary/lib/bvh.h
+++ b/Luminary/lib/bvh.h
@@ -40,7 +40,7 @@ struct Node8 {
 } typedef Node8;
 
 Node2* build_bvh_structure(
-  Triangle** triangles_io, unsigned int triangles_length, int* nodes_length_out);
+  Triangle** triangles_io, unsigned int* triangles_length_io, int* nodes_length_out);
 
 Node8* collapse_bvh(
   Node2* binary_nodes, const int binary_nodes_length, Triangle** triangles_io,

--- a/Luminary/lib/scene.c
+++ b/Luminary/lib/scene.c
@@ -10,7 +10,7 @@
 #include "light.h"
 
 static const int LINE_SIZE       = 4096;
-static const int CURRENT_VERSION = 2;
+static const int CURRENT_VERSION = 3;
 
 static int validate_filetype(const char* line) {
   int result = 0;
@@ -123,7 +123,9 @@ Scene load_scene(const char* filename, raytrace_instance** instance, char** outp
         &scene.camera.rotation.z, &scene.camera.fov);
     }
     else if (line[0] == 'l' && line[1] == ' ') {
-      sscanf(line, "%*c %f %f\n", &scene.camera.focal_length, &scene.camera.aperture_size);
+      sscanf(
+        line, "%*c %f %f %f\n", &scene.camera.focal_length, &scene.camera.aperture_size,
+        &scene.camera.exposure);
     }
     else if (line[0] == 's' && line[1] == ' ') {
       sscanf(line, "%*c %f %f %f\n", &azimuth, &altitude, &sun_strength);

--- a/Luminary/lib/scene.c
+++ b/Luminary/lib/scene.c
@@ -158,7 +158,7 @@ Scene load_scene(const char* filename, raytrace_instance** instance, char** outp
 
   int nodes_length;
 
-  Node2* initial_nodes = build_bvh_structure(&triangles, triangle_count, &nodes_length);
+  Node2* initial_nodes = build_bvh_structure(&triangles, &triangle_count, &nodes_length);
 
   Node8* nodes =
     collapse_bvh(initial_nodes, nodes_length, &triangles, triangle_count, &nodes_length);

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Luminary is a CUDA based Pathtracing renderer.
 
 This project is for fun and to learn more about `Computer Graphics`. There is no end goal, I will add whatever I feel like. The following is a list of things that I may do in the future.
 
-- Implement faster and higher quality binary BVH construction.
 - Implement Clouds.
 - Implement volumetric lighting.
+- Implement parallel BVH construction.
+- Implement SAH based node collapsing.
 - Implement refraction.
 
 As a denoiser I use `Optix` since any non machine learning denoiser is quite frankly not all that great and machine learning is out of the scope of this project.
@@ -44,7 +45,7 @@ You can get `Blender` to link the material textures to `map_Ns` by setting them 
 A whole scene is arranged through `*.lum` files which are in the following format:
 ```
 Luminary
-v 2
+v 3
 # Comments start with a # symbol
 # Comments may only appear after the first two lines
 # This example demonstrates this particular version of lum
@@ -56,8 +57,8 @@ m Meshes/Example.obj
 # c [Pos.x | Pos.y | Pos.z | Rotation.x | Rotation.y | Rotation.z | FOV]
 c 2.0 0.3 -0.06 0.0 1.570796 0.0 2.0
 # Camera lens parameters
-# l [Focal Length | Aperture Size] (Default Aperture Size=0.0)
-l 20.0 0.4
+# l [Focal Length | Aperture Size | Exposure] (Default Aperture Size=0.0)
+l 20.0 0.4 2.0
 #
 # Sun parameters
 # s [Azimuth | Altitude | Intensity]
@@ -118,7 +119,7 @@ The `SDL2` library is used for the realtime mode. Details about its authors and 
 
 # Literature
 
-This is a list of papers I used for this project so far:
+This is a list of papers I used for this project so far. Note that some techniques presented in these papers are not implemented at the moment but their ideas were helpful nonetheless:
 
 - J. Frisvad, _Building an Orthonormal Basis from a 3D Unit Vector Without Normalization_, Journal of Graphics Tools, 16(3), pp. 151-159, 2012
 - T. Möller, B. Trumbore, _Fast, Minimum Storage Ray-Triangle Intersection_, Journal of Graphics Tools, 2, pp. 21-28, 1997.
@@ -130,4 +131,6 @@ This is a list of papers I used for this project so far:
 - B. Smolka, M. Szczepanski, K.N. Plataniotis, A.N. Venetsanopoulos, _Fast Modified Vector Median Filter_, Canadian Conference on Electrical and Computer Engineering 2001, 2, pp. 1315-1320, 2001.
 - J. Boksansky, _Crash Course in BRDF Implementation_, https://boksajak.github.io/blog/BRDF, 2021.
 - S. Lagarde, C. de Rousiers, _Moving Frostbite to Physically Based Rendering_, 2014.
-- E. Heitz, L. Belcour, V. Ostromoukhov, D. Coeurjolly and J. Iehl, _A Low-Discrepancy Sampler that Distributes Monte Carlo Errors as a Blue Noise in Screen Space_, SIGGRAPH'19 Talks, 2019.
+- L. Belcour, D. Coeurjolly, E. Heitz, J. Iehl and V. Ostromoukhov, _A Low-Discrepancy Sampler that Distributes Monte Carlo Errors as a Blue Noise in Screen Space_, SIGGRAPH'19 Talks, 2019.
+- A. Dietrich, H. Friedrich and M. Stich, _Spatial splits in bounding volume hierarchies_, HPG '09: Proceedings of the Conference on High Performance Graphics 2009, pp. 7-13, 2009.
+- A. Ebert, V. Fuetterling, C. Lojewski and F. Pfreundt, _Parallel Spatial Splits in Bounding Volume Hierarchies_, Eurographics Symposium on Parallel Graphics and Visualization, 2016.


### PR DESCRIPTION
This implements spatial splits in the bvh construction. Due to further changes this also improves build time by a good amount. Render performance increased measurably by about 5 to 10%. This is kind of inline with what was to be expected as the paper reports performance increases of 10 to 20% in most scenes while obviously the traversal kernel makes up only half of Luminary's kernels execution time.

At this point one may implement a parallel version of the construction algorithm, reducing construction time massively or one could implement SAH based node collapsing for the wide bvh. The former is not really all that important to me as construction time is good enough and the latter yields at best 10% performance for the traversal which means at best like 5%.