### PR TITLE
Normal maps

### DIFF
--- a/LumFileDocs.md
+++ b/LumFileDocs.md
@@ -49,9 +49,6 @@ Defines which of the available fresnel approximations is used:
   - 0 = Schlick
   - 1 = Fdez-Aguera
 
-`MATERIAL BVHALPHA [INT32]`<br/>
-Set 1 to check for fully transparent hits during BVH traversal, 0 else. This fixes early ray termination in scenes that make much use of alpha cutoff. However, it comes at a mild performance cost.
-
 `MATERIAL ALPHACUT [FP32]`<br/>
 Every alpha value smaller than this value is automatically treated as 0, i.e., fully transparent. Number must be in the range [0,1].
 

--- a/LumFileDocs.md
+++ b/LumFileDocs.md
@@ -308,6 +308,8 @@ Set 1 to activate flashlight mode, that is, the toy is behind the camera and emi
 
 Meshes must be in the Wavefront OBJ (`*.obj`) file format. Geometric vertices, texture coordinates, vertex normals and triangle/quad faces are supported. Textures are to be referenced through a `*.mtl` which has the same name as the `*.obj` file.
 
+>📝 A common cause of light leaking / broken lighting is unrealistic vertex normals. Issues appear if the vertex normals represent a surface that is too different from the actual geometry. Performing steps like edge splitting often alleviate this issue at the cost of a higher triangle count.
+
 # Textures
 
 Textures must be in the Portable Network Graphics (`*.png`) file format. They need to have 8 bit channel depth. Supported color formats are `Truecolor` (RGB) and `Truecolor with alpha` (RGBA). They may use filters but may not be interlaced. Textures are used in three different ways:

--- a/LumFileDocs.md
+++ b/LumFileDocs.md
@@ -327,7 +327,7 @@ Textures must be in the Portable Network Graphics (`*.png`) file format. They ne
    - Green: Metallic
    - Blue: Unused
    - Alpha: Unused
- - Normal Textures
+ - Normal Textures (OpenGL format)
    - Red: Tangent X
    - Green: Tangent Y
    - Blue: Tangent Z

--- a/LumFileDocs.md
+++ b/LumFileDocs.md
@@ -330,18 +330,25 @@ Textures must be in the Portable Network Graphics (`*.png`) file format. They ne
    - Green: Metallic
    - Blue: Unused
    - Alpha: Unused
+ - Normal Textures
+   - Red: Tangent X
+   - Green: Tangent Y
+   - Blue: Tangent Z
+   - Alpha: Unused
 
 Textures are to be referenced in the `*.mtl` as follows:
 
-- map_Kd = Albedo Textures
-- map_Ke = Illuminance Textures
-- map_Ns = Material Textures
+- map_Kd   = Albedo Textures
+- map_Ke   = Illuminance Textures
+- map_Ns   = Material Textures
+- map_Bump = Normal Textures (Spaces are not allowed in path)
 
 In `Blender` these map types correspond to:
 
-- map_Kd = Albedo
-- map_Ke = Emission
-- map_Ns = Smoothness
+- map_Kd   = Albedo
+- map_Ke   = Emission
+- map_Ns   = Smoothness
+- map_Bump = Normal
 
 >📝 There was a [bug](https://developer.blender.org/D14519) in Blender before 02.04.22 where map_Ke were not exported. If you encounter any issues of Luminary detecting no emissive triangles, use a newer Blender version for the export.
 

--- a/include/light.h
+++ b/include/light.h
@@ -3,6 +3,6 @@
 
 #include "utils.h"
 
-void process_lights(Scene* scene, TextureRGBA* textures);
+void lights_build_set_from_triangles(Scene* scene, TextureRGBA* textures);
 
 #endif /* LIGHT_H */

--- a/include/lum.h
+++ b/include/lum.h
@@ -7,7 +7,7 @@
 #include "wavefront.h"
 
 int lum_validate_file(FILE* file);
-void lum_parse_file(FILE* file, Scene* scene, General* general, Wavefront_Content* content);
+void lum_parse_file(FILE* file, Scene* scene, General* general, WavefrontContent* content);
 void lum_write_file(FILE* file, RaytraceInstance* instance);
 
 #endif /* LUM_H */

--- a/include/raytrace.h
+++ b/include/raytrace.h
@@ -14,7 +14,7 @@ extern "C" {
 void initialize_device();
 RaytraceInstance* init_raytracing(
   General general, DeviceBuffer* albedo_atlas, int albedo_atlas_length, DeviceBuffer* illuminance_atlas, int illuminance_atlas_length,
-  DeviceBuffer* material_atlas, int material_atlas_length, Scene scene);
+  DeviceBuffer* material_atlas, int material_atlas_length, DeviceBuffer* normal_atlas, int normal_atlas_length, Scene scene);
 void reset_raytracing(RaytraceInstance* instance);
 void allocate_buffers(RaytraceInstance* instance);
 void update_jitter(RaytraceInstance* instance);

--- a/include/raytrace.h
+++ b/include/raytrace.h
@@ -12,9 +12,7 @@ extern "C" {
 #endif
 
 void initialize_device();
-RaytraceInstance* init_raytracing(
-  General general, DeviceBuffer* albedo_atlas, int albedo_atlas_length, DeviceBuffer* illuminance_atlas, int illuminance_atlas_length,
-  DeviceBuffer* material_atlas, int material_atlas_length, DeviceBuffer* normal_atlas, int normal_atlas_length, Scene scene);
+RaytraceInstance* init_raytracing(General general, TextureAtlas tex_atlas, Scene scene);
 void reset_raytracing(RaytraceInstance* instance);
 void allocate_buffers(RaytraceInstance* instance);
 void update_jitter(RaytraceInstance* instance);

--- a/include/raytrace.h
+++ b/include/raytrace.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif
 
 void initialize_device();
-RaytraceInstance* init_raytracing(General general, TextureAtlas tex_atlas, Scene scene);
+void raytracing_init(RaytraceInstance** _instance, General general, TextureAtlas tex_atlas, Scene* scene);
 void reset_raytracing(RaytraceInstance* instance);
 void allocate_buffers(RaytraceInstance* instance);
 void update_jitter(RaytraceInstance* instance);

--- a/include/scene.h
+++ b/include/scene.h
@@ -4,12 +4,15 @@
 #include "bvh.h"
 #include "structs.h"
 #include "utils.h"
+#include "wavefront.h"
 
-RaytraceInstance* load_scene(const char* filename);
-RaytraceInstance* load_obj_as_scene(char* filename);
-void serialize_scene(RaytraceInstance* instance);
+void scene_init(Scene** _scene);
+void scene_create_from_wavefront(Scene* scene, WavefrontContent* content);
+RaytraceInstance* scene_load_lum(const char* filename);
+RaytraceInstance* scene_load_obj(char* filename);
+void scene_serialize(RaytraceInstance* instance);
 void free_atlases(RaytraceInstance* instance);
 void free_strings(RaytraceInstance* instance);
-void free_scene(Scene scene);
+void scene_clear(Scene** scene);
 
 #endif /* SCENE_H */

--- a/include/structs.h
+++ b/include/structs.h
@@ -168,7 +168,7 @@ struct TextureAssignment {
   uint16_t albedo_map;
   uint16_t illuminance_map;
   uint16_t material_map;
-  uint16_t _p;
+  uint16_t normal_map;
 } typedef TextureAssignment;
 
 struct TextureG {

--- a/include/utils.h
+++ b/include/utils.h
@@ -269,8 +269,10 @@ struct RaytraceInstance {
   DeviceBuffer* illuminance_atlas;
   int illuminance_atlas_length;
   DeviceBuffer* material_atlas;
-  DeviceBuffer* cloud_noise;
   int material_atlas_length;
+  DeviceBuffer* normal_atlas;
+  int normal_atlas_length;
+  DeviceBuffer* cloud_noise;
   int max_ray_depth;
   int reservoir_size;
   int offline_samples;

--- a/include/utils.h
+++ b/include/utils.h
@@ -238,14 +238,14 @@ struct Scene {
 } typedef Scene;
 
 struct TextureAtlas {
-  DeviceBuffer* albedo_atlas;
-  int albedo_atlas_length;
-  DeviceBuffer* illuminance_atlas;
-  int illuminance_atlas_length;
-  DeviceBuffer* material_atlas;
-  int material_atlas_length;
-  DeviceBuffer* normal_atlas;
-  int normal_atlas_length;
+  DeviceBuffer* albedo;
+  int albedo_length;
+  DeviceBuffer* illuminance;
+  int illuminance_length;
+  DeviceBuffer* material;
+  int material_length;
+  DeviceBuffer* normal;
+  int normal_length;
 } typedef TextureAtlas;
 
 struct RaytraceInstance {

--- a/include/utils.h
+++ b/include/utils.h
@@ -237,6 +237,17 @@ struct Scene {
   GlobalMaterial material;
 } typedef Scene;
 
+struct TextureAtlas {
+  DeviceBuffer* albedo_atlas;
+  int albedo_atlas_length;
+  DeviceBuffer* illuminance_atlas;
+  int illuminance_atlas_length;
+  DeviceBuffer* material_atlas;
+  int material_atlas_length;
+  DeviceBuffer* normal_atlas;
+  int normal_atlas_length;
+} typedef TextureAtlas;
+
 struct RaytraceInstance {
   unsigned int width;
   unsigned int height;
@@ -261,17 +272,9 @@ struct RaytraceInstance {
   DeviceBuffer* light_records;
   DeviceBuffer* bounce_records;
   DeviceBuffer* buffer_8bit;
-  DeviceBuffer* albedo_atlas;
   DeviceBuffer* light_samples_1;
   DeviceBuffer* light_samples_2;
   DeviceBuffer* light_eval_data;
-  int albedo_atlas_length;
-  DeviceBuffer* illuminance_atlas;
-  int illuminance_atlas_length;
-  DeviceBuffer* material_atlas;
-  int material_atlas_length;
-  DeviceBuffer* normal_atlas;
-  int normal_atlas_length;
   DeviceBuffer* cloud_noise;
   int max_ray_depth;
   int reservoir_size;
@@ -295,6 +298,7 @@ struct RaytraceInstance {
   DeviceBuffer* raydir_buffer;
   DeviceBuffer* trace_result_buffer;
   DeviceBuffer* state_buffer;
+  TextureAtlas tex_atlas;
 } typedef RaytraceInstance;
 
 #ifndef min

--- a/include/utils.h
+++ b/include/utils.h
@@ -215,7 +215,6 @@ struct GlobalMaterial {
   RGBF default_material;
   MaterialFresnel fresnel;
   int lights_active;
-  int bvh_alpha_cutoff;
   float alpha_cutoff;
 } typedef GlobalMaterial;
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -27,6 +27,8 @@
 #define LIGHT_ID_TOY 0xfffffffeu
 #define LIGHT_ID_NONE 0xfffffff1u
 
+#define TEXTURE_NONE ((uint16_t) 0xffffu)
+
 enum OutputImageFormat { IMGFORMAT_PNG = 0, IMGFORMAT_QOI = 1 } typedef OutputImageFormat;
 
 enum ShadingMode {

--- a/include/wavefront.h
+++ b/include/wavefront.h
@@ -41,9 +41,15 @@ struct Wavefront_Material {
   uint16_t albedo_texture;
   uint16_t illuminance_texture;
   uint16_t material_texture;
+  uint16_t normal_texture;
 } typedef Wavefront_Material;
 
-enum Wavefront_TextureInstanceType { WF_ALBEDO = 0, WF_ILLUMINANCE = 1, WF_MATERIAL = 2 } typedef Wavefront_TextureInstanceType;
+enum Wavefront_TextureInstanceType {
+  WF_ALBEDO      = 0,
+  WF_ILLUMINANCE = 1,
+  WF_MATERIAL    = 2,
+  WF_NORMAL      = 3
+} typedef Wavefront_TextureInstanceType;
 
 struct Wavefront_TextureInstance {
   size_t hash;
@@ -74,6 +80,8 @@ struct Wavefront_Content {
   unsigned int illuminance_maps_length;
   TextureRGBA* material_maps;
   unsigned int material_maps_length;
+  TextureRGBA* normal_maps;
+  unsigned int normal_maps_length;
   Wavefront_TextureList* texture_list;
 } typedef Wavefront_Content;
 

--- a/include/wavefront.h
+++ b/include/wavefront.h
@@ -6,24 +6,24 @@
 
 #include "structs.h"
 
-struct Wavefront_Vertex {
+struct WavefrontVertex {
   float x;
   float y;
   float z;
-} typedef Wavefront_Vertex;
+} typedef WavefrontVertex;
 
-struct Wavefront_Normal {
+struct WavefrontNormal {
   float x;
   float y;
   float z;
-} typedef Wavefront_Normal;
+} typedef WavefrontNormal;
 
-struct Wavefront_UV {
+struct WavefrontUV {
   float u;
   float v;
-} typedef Wavefront_UV;
+} typedef WavefrontUV;
 
-struct Wavefront_Triangle {
+struct WavefrontTriangle {
   int v1;
   int v2;
   int v3;
@@ -34,45 +34,45 @@ struct Wavefront_Triangle {
   int vn2;
   int vn3;
   uint16_t object;
-} typedef Wavefront_Triangle;
+} typedef WavefrontTriangle;
 
-struct Wavefront_Material {
+struct WavefrontMaterial {
   size_t hash;
   uint16_t albedo_texture;
   uint16_t illuminance_texture;
   uint16_t material_texture;
   uint16_t normal_texture;
-} typedef Wavefront_Material;
+} typedef WavefrontMaterial;
 
-enum Wavefront_TextureInstanceType {
+enum WavefrontTextureInstanceType {
   WF_ALBEDO      = 0,
   WF_ILLUMINANCE = 1,
   WF_MATERIAL    = 2,
   WF_NORMAL      = 3
-} typedef Wavefront_TextureInstanceType;
+} typedef WavefrontTextureInstanceType;
 
-struct Wavefront_TextureInstance {
+struct WavefrontTextureInstance {
   size_t hash;
-  Wavefront_TextureInstanceType type;
+  WavefrontTextureInstanceType type;
   uint16_t offset;
-} typedef Wavefront_TextureInstance;
+} typedef WavefrontTextureInstance;
 
-struct Wavefront_TextureList {
-  Wavefront_TextureInstance* textures;
+struct WavefrontTextureList {
+  WavefrontTextureInstance* textures;
   uint32_t count;
   uint32_t length;
-} typedef Wavefront_TextureList;
+} typedef WavefrontTextureList;
 
-struct Wavefront_Content {
-  Wavefront_Vertex* vertices;
+struct WavefrontContent {
+  WavefrontVertex* vertices;
   int vertices_length;
-  Wavefront_Normal* normals;
+  WavefrontNormal* normals;
   int normals_length;
-  Wavefront_UV* uvs;
+  WavefrontUV* uvs;
   int uvs_length;
-  Wavefront_Triangle* triangles;
+  WavefrontTriangle* triangles;
   unsigned int triangles_length;
-  Wavefront_Material* materials;
+  WavefrontMaterial* materials;
   unsigned int materials_length;
   TextureRGBA* albedo_maps;
   unsigned int albedo_maps_length;
@@ -82,13 +82,13 @@ struct Wavefront_Content {
   unsigned int material_maps_length;
   TextureRGBA* normal_maps;
   unsigned int normal_maps_length;
-  Wavefront_TextureList* texture_list;
-} typedef Wavefront_Content;
+  WavefrontTextureList* texture_list;
+} typedef WavefrontContent;
 
-Wavefront_Content create_wavefront_content();
-void free_wavefront_content(Wavefront_Content content);
-int read_wavefront_file(const char* filename, Wavefront_Content* io_content);
-TextureAssignment* get_texture_assignments(Wavefront_Content content);
-unsigned int convert_wavefront_content(Triangle** triangles, Wavefront_Content content);
+void wavefront_init(WavefrontContent** content);
+void wavefront_clear(WavefrontContent** content);
+int wavefront_read_file(WavefrontContent* _content, const char* filename);
+TextureAssignment* wavefront_generate_texture_assignments(WavefrontContent* content);
+unsigned int wavefront_convert_content(WavefrontContent* content, Triangle** triangles);
 
 #endif /* WAVEFRONT_H */

--- a/src/Luminary.c
+++ b/src/Luminary.c
@@ -160,16 +160,16 @@ int main(int argc, char* argv[]) {
 
   switch (file_type) {
     case LUM_FILE:
-      instance = load_scene(argv[1]);
+      instance = scene_load_lum(argv[1]);
       break;
     case OBJ_FILE:
-      instance = load_obj_as_scene(argv[1]);
+      instance = scene_load_obj(argv[1]);
       break;
     case BAKED_FILE:
       instance = load_baked(argv[1]);
       break;
     default:
-      instance = load_scene(argv[1]);
+      instance = scene_load_lum(argv[1]);
       break;
   }
 

--- a/src/UI/UI.c
+++ b/src/UI/UI.c
@@ -111,7 +111,7 @@ static UITab create_general_export_panels(UI* ui, RaytraceInstance* instance) {
   panels[i++] = create_tab(ui, &(ui->subtab), "Renderer\nMaterials\nExport");
   panels[i++] = create_dropdown(ui, "Snapshot Resolution", &(instance->snap_resolution), 0, 2, "Window\0Render", 2);
   panels[i++] = create_dropdown(ui, "Output Image Format", &(instance->image_format), 0, 2, "PNG\0QOI", 3);
-  panels[i++] = create_button(ui, "Export Settings", instance, (void (*)(void*)) serialize_scene, 0);
+  panels[i++] = create_button(ui, "Export Settings", instance, (void (*)(void*)) scene_serialize, 0);
   panels[i++] = create_button(ui, "Export Baked File", instance, (void (*)(void*)) serialize_baked, 0);
 
   tab.panels      = panels;

--- a/src/UI/UI.c
+++ b/src/UI/UI.c
@@ -83,7 +83,6 @@ static UITab create_general_material_panels(UI* ui, RaytraceInstance* instance) 
   panels[i++] = create_tab(ui, &(ui->tab), "General\nCamera\nSky\nOcean\nToy");
   panels[i++] = create_tab(ui, &(ui->subtab), "Renderer\nMaterials\nExport");
   panels[i++] = create_check(ui, "Lights", &(instance->scene_gpu.material.lights_active), 1);
-  panels[i++] = create_check(ui, "BVH Alpha Cutoff", &(instance->scene_gpu.material.bvh_alpha_cutoff), 1);
   panels[i++] = create_slider(ui, "Alpha Cutoff", &(instance->scene_gpu.material.alpha_cutoff), 1, 0.0005f, 0.0f, 1.0f, 0, 0);
   panels[i++] = create_slider(ui, "Default Smoothness", &(instance->scene_gpu.material.default_material.r), 1, 0.001f, 0.0f, 1.0f, 0, 0);
   panels[i++] = create_slider(ui, "Default Metallic", &(instance->scene_gpu.material.default_material.g), 1, 0.001f, 0.0f, 1.0f, 0, 0);

--- a/src/baked.c
+++ b/src/baked.c
@@ -182,25 +182,25 @@ RaytraceInstance* load_baked(const char* filename) {
   fseek(file, head[6], SEEK_SET);
   fread(scene.texture_assignments, sizeof(TextureAssignment) * scene.materials_length, 1, file);
 
-  TextureRGBA* albedo_tex      = load_textures(file, instance->tex_atlas.albedo_atlas_length, head[7]);
-  TextureRGBA* illuminance_tex = load_textures(file, instance->tex_atlas.illuminance_atlas_length, head[8]);
-  TextureRGBA* material_tex    = load_textures(file, instance->tex_atlas.material_atlas_length, head[9]);
-  TextureRGBA* normal_tex      = load_textures(file, instance->tex_atlas.normal_atlas_length, head[10]);
+  TextureRGBA* albedo_tex      = load_textures(file, instance->tex_atlas.albedo_length, head[7]);
+  TextureRGBA* illuminance_tex = load_textures(file, instance->tex_atlas.illuminance_length, head[8]);
+  TextureRGBA* material_tex    = load_textures(file, instance->tex_atlas.material_length, head[9]);
+  TextureRGBA* normal_tex      = load_textures(file, instance->tex_atlas.normal_length, head[10]);
 
   TextureAtlas tex_atlas = {
-    .albedo_atlas             = cudatexture_allocate_to_buffer(albedo_tex, instance->tex_atlas.albedo_atlas_length),
-    .albedo_atlas_length      = instance->tex_atlas.albedo_atlas_length,
-    .illuminance_atlas        = cudatexture_allocate_to_buffer(illuminance_tex, instance->tex_atlas.illuminance_atlas_length),
-    .illuminance_atlas_length = instance->tex_atlas.illuminance_atlas_length,
-    .material_atlas           = cudatexture_allocate_to_buffer(material_tex, instance->tex_atlas.material_atlas_length),
-    .material_atlas_length    = instance->tex_atlas.material_atlas_length,
-    .normal_atlas             = cudatexture_allocate_to_buffer(normal_tex, instance->tex_atlas.normal_atlas_length),
-    .normal_atlas_length      = instance->tex_atlas.normal_atlas_length};
+    .albedo             = cudatexture_allocate_to_buffer(albedo_tex, instance->tex_atlas.albedo_length),
+    .albedo_length      = instance->tex_atlas.albedo_length,
+    .illuminance        = cudatexture_allocate_to_buffer(illuminance_tex, instance->tex_atlas.illuminance_length),
+    .illuminance_length = instance->tex_atlas.illuminance_length,
+    .material           = cudatexture_allocate_to_buffer(material_tex, instance->tex_atlas.material_length),
+    .material_length    = instance->tex_atlas.material_length,
+    .normal             = cudatexture_allocate_to_buffer(normal_tex, instance->tex_atlas.normal_length),
+    .normal_length      = instance->tex_atlas.normal_length};
 
-  free_textures(albedo_tex, instance->tex_atlas.albedo_atlas_length);
-  free_textures(illuminance_tex, instance->tex_atlas.illuminance_atlas_length);
-  free_textures(material_tex, instance->tex_atlas.material_atlas_length);
-  free_textures(normal_tex, instance->tex_atlas.normal_atlas_length);
+  free_textures(albedo_tex, instance->tex_atlas.albedo_length);
+  free_textures(illuminance_tex, instance->tex_atlas.illuminance_length);
+  free_textures(material_tex, instance->tex_atlas.material_length);
+  free_textures(normal_tex, instance->tex_atlas.normal_length);
 
   scene.traversal_triangles = construct_traversal_triangles(scene.triangles, scene.triangles_length, scene.texture_assignments);
 
@@ -310,14 +310,11 @@ void serialize_baked(RaytraceInstance* instance) {
   head[5] =
     write_data(file, instance->scene_gpu.triangle_lights_length, sizeof(TriangleLight), instance->scene_gpu.triangle_lights, GPU_PTR);
   head[6] = write_data(file, instance->scene_gpu.materials_length, sizeof(TextureAssignment), instance->scene_gpu.texture_assignments, 1);
-  head[7] =
-    write_data(file, instance->tex_atlas.albedo_atlas_length, 1, device_buffer_get_pointer(instance->tex_atlas.albedo_atlas), TEX_PTR);
-  head[8] = write_data(
-    file, instance->tex_atlas.illuminance_atlas_length, 1, device_buffer_get_pointer(instance->tex_atlas.illuminance_atlas), TEX_PTR);
-  head[9] =
-    write_data(file, instance->tex_atlas.material_atlas_length, 1, device_buffer_get_pointer(instance->tex_atlas.material_atlas), TEX_PTR);
-  head[10] =
-    write_data(file, instance->tex_atlas.normal_atlas_length, 1, device_buffer_get_pointer(instance->tex_atlas.normal_atlas), TEX_PTR);
+  head[7] = write_data(file, instance->tex_atlas.albedo_length, 1, device_buffer_get_pointer(instance->tex_atlas.albedo), TEX_PTR);
+  head[8] =
+    write_data(file, instance->tex_atlas.illuminance_length, 1, device_buffer_get_pointer(instance->tex_atlas.illuminance), TEX_PTR);
+  head[9]  = write_data(file, instance->tex_atlas.material_length, 1, device_buffer_get_pointer(instance->tex_atlas.material), TEX_PTR);
+  head[10] = write_data(file, instance->tex_atlas.normal_length, 1, device_buffer_get_pointer(instance->tex_atlas.normal), TEX_PTR);
   head[12] = 1 + instance->settings.mesh_files_count;
 
   void* strings;

--- a/src/baked.c
+++ b/src/baked.c
@@ -182,24 +182,29 @@ RaytraceInstance* load_baked(const char* filename) {
   fseek(file, head[6], SEEK_SET);
   fread(scene.texture_assignments, sizeof(TextureAssignment) * scene.materials_length, 1, file);
 
-  TextureRGBA* albedo_tex = load_textures(file, instance->albedo_atlas_length, head[7]);
-  void* albedo_atlas      = cudatexture_allocate_to_buffer(albedo_tex, instance->albedo_atlas_length);
-  free_textures(albedo_tex, instance->albedo_atlas_length);
-  TextureRGBA* illuminance_tex = load_textures(file, instance->illuminance_atlas_length, head[8]);
-  void* illuminance_atlas      = cudatexture_allocate_to_buffer(illuminance_tex, instance->illuminance_atlas_length);
-  free_textures(illuminance_tex, instance->illuminance_atlas_length);
-  TextureRGBA* material_tex = load_textures(file, instance->material_atlas_length, head[9]);
-  void* material_atlas      = cudatexture_allocate_to_buffer(material_tex, instance->material_atlas_length);
-  free_textures(material_tex, instance->material_atlas_length);
-  TextureRGBA* normal_tex = load_textures(file, instance->normal_atlas_length, head[10]);
-  void* normal_atlas      = cudatexture_allocate_to_buffer(normal_tex, instance->normal_atlas_length);
-  free_textures(normal_tex, instance->normal_atlas_length);
+  TextureRGBA* albedo_tex      = load_textures(file, instance->tex_atlas.albedo_atlas_length, head[7]);
+  TextureRGBA* illuminance_tex = load_textures(file, instance->tex_atlas.illuminance_atlas_length, head[8]);
+  TextureRGBA* material_tex    = load_textures(file, instance->tex_atlas.material_atlas_length, head[9]);
+  TextureRGBA* normal_tex      = load_textures(file, instance->tex_atlas.normal_atlas_length, head[10]);
+
+  TextureAtlas tex_atlas = {
+    .albedo_atlas             = cudatexture_allocate_to_buffer(albedo_tex, instance->tex_atlas.albedo_atlas_length),
+    .albedo_atlas_length      = instance->tex_atlas.albedo_atlas_length,
+    .illuminance_atlas        = cudatexture_allocate_to_buffer(illuminance_tex, instance->tex_atlas.illuminance_atlas_length),
+    .illuminance_atlas_length = instance->tex_atlas.illuminance_atlas_length,
+    .material_atlas           = cudatexture_allocate_to_buffer(material_tex, instance->tex_atlas.material_atlas_length),
+    .material_atlas_length    = instance->tex_atlas.material_atlas_length,
+    .normal_atlas             = cudatexture_allocate_to_buffer(normal_tex, instance->tex_atlas.normal_atlas_length),
+    .normal_atlas_length      = instance->tex_atlas.normal_atlas_length};
+
+  free_textures(albedo_tex, instance->tex_atlas.albedo_atlas_length);
+  free_textures(illuminance_tex, instance->tex_atlas.illuminance_atlas_length);
+  free_textures(material_tex, instance->tex_atlas.material_atlas_length);
+  free_textures(normal_tex, instance->tex_atlas.normal_atlas_length);
 
   scene.traversal_triangles = construct_traversal_triangles(scene.triangles, scene.triangles_length, scene.texture_assignments);
 
-  RaytraceInstance* final = init_raytracing(
-    instance->settings, albedo_atlas, instance->albedo_atlas_length, illuminance_atlas, instance->illuminance_atlas_length, material_atlas,
-    instance->material_atlas_length, normal_atlas, instance->normal_atlas_length, scene);
+  RaytraceInstance* final = init_raytracing(instance->settings, tex_atlas, scene);
 
   final->scene_gpu.sky.stars             = (Star*) 0;
   final->scene_gpu.sky.cloud.initialized = 0;
@@ -304,11 +309,15 @@ void serialize_baked(RaytraceInstance* instance) {
   head[4] = write_data(file, instance->scene_gpu.nodes_length, sizeof(Node8), instance->scene_gpu.nodes, GPU_PTR);
   head[5] =
     write_data(file, instance->scene_gpu.triangle_lights_length, sizeof(TriangleLight), instance->scene_gpu.triangle_lights, GPU_PTR);
-  head[6]  = write_data(file, instance->scene_gpu.materials_length, sizeof(TextureAssignment), instance->scene_gpu.texture_assignments, 1);
-  head[7]  = write_data(file, instance->albedo_atlas_length, 1, device_buffer_get_pointer(instance->albedo_atlas), TEX_PTR);
-  head[8]  = write_data(file, instance->illuminance_atlas_length, 1, device_buffer_get_pointer(instance->illuminance_atlas), TEX_PTR);
-  head[9]  = write_data(file, instance->material_atlas_length, 1, device_buffer_get_pointer(instance->material_atlas), TEX_PTR);
-  head[10] = write_data(file, instance->normal_atlas_length, 1, device_buffer_get_pointer(instance->normal_atlas), TEX_PTR);
+  head[6] = write_data(file, instance->scene_gpu.materials_length, sizeof(TextureAssignment), instance->scene_gpu.texture_assignments, 1);
+  head[7] =
+    write_data(file, instance->tex_atlas.albedo_atlas_length, 1, device_buffer_get_pointer(instance->tex_atlas.albedo_atlas), TEX_PTR);
+  head[8] = write_data(
+    file, instance->tex_atlas.illuminance_atlas_length, 1, device_buffer_get_pointer(instance->tex_atlas.illuminance_atlas), TEX_PTR);
+  head[9] =
+    write_data(file, instance->tex_atlas.material_atlas_length, 1, device_buffer_get_pointer(instance->tex_atlas.material_atlas), TEX_PTR);
+  head[10] =
+    write_data(file, instance->tex_atlas.normal_atlas_length, 1, device_buffer_get_pointer(instance->tex_atlas.normal_atlas), TEX_PTR);
   head[12] = 1 + instance->settings.mesh_files_count;
 
   void* strings;

--- a/src/cuda/bvh.cuh
+++ b/src/cuda/bvh.cuh
@@ -17,6 +17,31 @@ __device__ unsigned char get_8bit(const unsigned int input, const unsigned int b
   return (input >> bitshift) & 0x000000FF;
 }
 
+/*
+ * Performs alpha test on traversal triangle
+ * @param t Triangle to test.
+ * @param t_id ID of tested triangle.
+ * @param coords Hit coordinates in triangle.
+ * @result 0 if opaque, 1 if transparent, 2 if alpha cutoff
+ */
+__device__ int bvh_triangle_intersection_alpha_test(TraversalTriangle t, uint32_t t_id, UV coords) {
+  if (!t.albedo_tex)
+    return 0;
+
+  const UV tex_coords = load_triangle_tex_coords(t_id, coords);
+  const float4 albedo = tex2D<float4>(device.albedo_atlas[t.albedo_tex], tex_coords.u, 1.0f - tex_coords.v);
+
+  if (albedo.w <= device_scene.material.alpha_cutoff) {
+    return 2;
+  }
+
+  if (albedo.w < 1.0f) {
+    return 1;
+  }
+
+  return 0;
+}
+
 #define STACK_SIZE_SM 10
 #define STACK_SIZE 32
 
@@ -38,7 +63,7 @@ __device__ unsigned char get_8bit(const unsigned int input, const unsigned int b
     stack_ptr++;                                      \
   }
 
-__device__ void traverse_bvh(const bool check_alpha) {
+__global__ __launch_bounds__(THREADS_PER_BLOCK, 9) void process_trace_tasks() {
   const uint16_t trace_task_count = device_trace_count[threadIdx.x + blockIdx.x * blockDim.x];
   uint16_t offset                 = 0;
 
@@ -320,47 +345,21 @@ __device__ void traverse_bvh(const bool check_alpha) {
 
         const TraversalTriangle triangle = load_traversal_triangle(triangle_index + triangle_task.x);
 
-        if (check_alpha) {
-          UV coords;
-          const float d = bvh_triangle_intersection_uv(triangle, origin, ray, coords);
+        UV coords;
+        const float d = bvh_triangle_intersection_uv(triangle, origin, ray, coords);
 
-          if (d < depth) {
-            bool opaque        = true;
-            bool allow_any_hit = true;
+        if (d < depth) {
+          const int alpha_result = bvh_triangle_intersection_alpha_test(triangle, triangle_index + triangle_task.x, coords);
 
-            if (triangle.albedo_tex) {
-              const UV tex_coords = load_triangle_tex_coords(triangle_index + triangle_task.x, coords);
-              const float4 albedo = tex2D<float4>(device.albedo_atlas[triangle.albedo_tex], tex_coords.u, 1.0f - tex_coords.v);
-
-              if (albedo.w <= device_scene.material.alpha_cutoff) {
-                opaque = false;
-              }
-
-              if (albedo.w < 1.0f) {
-                allow_any_hit = false;
-              }
-            }
-
-            if (opaque) {
-              if (device_iteration_type == TYPE_LIGHT && allow_any_hit) {
-                depth           = -1.0f;
-                hit_id          = REJECT_HIT;
-                triangle_task.y = 0;
-                node_task.y     = 0;
-                stack_ptr       = 0;
-                break;
-              }
-              else {
-                depth  = d;
-                hit_id = triangle_index + triangle_task.x;
-              }
-            }
+          if (device_iteration_type == TYPE_LIGHT && alpha_result == 0) {
+            depth           = -1.0f;
+            hit_id          = REJECT_HIT;
+            triangle_task.y = 0;
+            node_task.y     = 0;
+            stack_ptr       = 0;
+            break;
           }
-        }
-        else {
-          const float d = bvh_triangle_intersection(triangle, origin, ray);
-
-          if (d < depth) {
+          else if (alpha_result != 2) {
             depth  = d;
             hit_id = triangle_index + triangle_task.x;
           }
@@ -395,14 +394,6 @@ __device__ void traverse_bvh(const bool check_alpha) {
 
     } while (iterations_lost < 16);
   }
-}
-
-__global__ __launch_bounds__(THREADS_PER_BLOCK, 9) void process_trace_tasks() {
-  traverse_bvh(false);
-}
-
-__global__ __launch_bounds__(THREADS_PER_BLOCK, 9) void process_trace_tasks_alpha_cutoff() {
-  traverse_bvh(true);
 }
 
 #endif /* CU_BVH_H */

--- a/src/cuda/bvh.cuh
+++ b/src/cuda/bvh.cuh
@@ -25,7 +25,7 @@ __device__ unsigned char get_8bit(const unsigned int input, const unsigned int b
  * @result 0 if opaque, 1 if transparent, 2 if alpha cutoff
  */
 __device__ int bvh_triangle_intersection_alpha_test(TraversalTriangle t, uint32_t t_id, UV coords) {
-  if (!t.albedo_tex)
+  if (t.albedo_tex == TEXTURE_NONE)
     return 0;
 
   const UV tex_coords = load_triangle_tex_coords(t_id, coords);

--- a/src/cuda/geometry.cuh
+++ b/src/cuda/geometry.cuh
@@ -83,7 +83,7 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 7) void process_geometry_tasks()
 
     vec3 terminator = terminator_fix(task.position, vertex, edge1, edge2, vertex_normal, edge1_normal, edge2_normal, coords);
 
-    if (maps.w) {
+    if (maps.w != TEXTURE_NONE) {
       const float4 normal_f = tex2D<float4>(device.normal_atlas[maps.w], tex_coords.u, 1.0f - tex_coords.v);
 
       vec3 map_normal = get_vector(normal_f.x, normal_f.y, normal_f.z);
@@ -100,7 +100,7 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 7) void process_geometry_tasks()
     float metallic;
     float intensity = device_scene.material.default_material.b;
 
-    if (maps.z) {
+    if (maps.z != TEXTURE_NONE) {
       const float4 material_f = tex2D<float4>(device.material_atlas[maps.z], tex_coords.u, 1.0f - tex_coords.v);
 
       roughness = (1.0f - material_f.x);
@@ -113,7 +113,7 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 7) void process_geometry_tasks()
 
     RGBAF albedo;
 
-    if (maps.x) {
+    if (maps.x != TEXTURE_NONE) {
       const float4 albedo_f = tex2D<float4>(device.albedo_atlas[maps.x], tex_coords.u, 1.0f - tex_coords.v);
       albedo.r              = albedo_f.x;
       albedo.g              = albedo_f.y;
@@ -129,7 +129,7 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 7) void process_geometry_tasks()
 
     RGBAhalf emission = get_RGBAhalf(0.0f, 0.0f, 0.0f, 0.0f);
 
-    if (maps.y && device_scene.material.lights_active) {
+    if (maps.y != TEXTURE_NONE && device_scene.material.lights_active) {
       const float4 illuminance_f = tex2D<float4>(device.illuminance_atlas[maps.y], tex_coords.u, 1.0f - tex_coords.v);
 
       emission = get_RGBAhalf(illuminance_f.x, illuminance_f.y, illuminance_f.z, illuminance_f.w);
@@ -282,7 +282,7 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 9) void process_debug_geometry_t
 
       const ushort4 maps = __ldg((ushort4*) (device_texture_assignments + texture_object));
 
-      if (maps.x) {
+      if (maps.x != TEXTURE_NONE) {
         const float4 albedo_f = tex2D<float4>(device.albedo_atlas[maps.x], tex_coords.u, 1.0f - tex_coords.v);
         color                 = add_color(color, get_color(albedo_f.x, albedo_f.y, albedo_f.z));
       }
@@ -290,7 +290,7 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 9) void process_debug_geometry_t
         color = add_color(color, get_color(0.9f, 0.9f, 0.9f));
       }
 
-      if (maps.y && device_scene.material.lights_active) {
+      if (maps.y != TEXTURE_NONE && device_scene.material.lights_active) {
         const float4 illuminance_f = tex2D<float4>(device.illuminance_atlas[maps.y], tex_coords.u, 1.0f - tex_coords.v);
 
         color = add_color(color, get_color(illuminance_f.x, illuminance_f.y, illuminance_f.z));
@@ -338,7 +338,7 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 9) void process_debug_geometry_t
 
       const ushort4 maps = __ldg((ushort4*) (device_texture_assignments + texture_object));
 
-      if (maps.w) {
+      if (maps.w != TEXTURE_NONE) {
         const float4 normal_f = tex2D<float4>(device.normal_atlas[maps.w], tex_coords.u, 1.0f - tex_coords.v);
 
         vec3 map_normal = get_vector(normal_f.x, normal_f.y, normal_f.z);
@@ -420,7 +420,7 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 9) void process_debug_geometry_t
       else {
         const ushort4 maps = __ldg((ushort4*) (device_texture_assignments + texture_object));
 
-        if (maps.x) {
+        if (maps.x != TEXTURE_NONE) {
           const float4 albedo_f = tex2D<float4>(device.albedo_atlas[maps.x], tex_coords.u, 1.0f - tex_coords.v);
           color                 = get_color(albedo_f.x, albedo_f.y, albedo_f.z);
         }

--- a/src/cuda/math.cuh
+++ b/src/cuda/math.cuh
@@ -1060,6 +1060,16 @@ __device__ int material_is_mirror(const float roughness, const float metallic) {
 // Computes tangent space for use with normal mapping without precomputation
 // http://www.thetenthplanet.de/archives/1180
 __device__ Mat3x3 cotangent_frame(vec3 normal, vec3 e1, vec3 e2, UV t1, UV t2) {
+  e1 = normalize_vector(e1);
+  e2 = normalize_vector(e2);
+
+  const float abs1 = __frsqrt_rn(t1.u * t1.u + t1.v * t1.v);
+  t1.u *= abs1;
+  t1.v *= abs1;
+  const float abs2 = __frsqrt_rn(t2.u * t2.u + t2.v * t2.v);
+  t2.u *= abs2;
+  t2.v *= abs2;
+
   const vec3 a1 = cross_product(e2, normal);
   const vec3 a2 = cross_product(normal, e1);
 

--- a/src/cuda/ocean.cuh
+++ b/src/cuda/ocean.cuh
@@ -137,17 +137,33 @@ __device__ vec3 ocean_get_normal(vec3 p, const float diff) {
 }
 
 __device__ float ocean_far_distance(const vec3 origin, const vec3 ray) {
-  const float depth = (device_scene.ocean.height - origin.y) / ray.y;
+  const float d1 = device_scene.ocean.height - origin.y;
+  const float d2 = d1 + device_scene.ocean.amplitude;
 
-  return (depth >= eps) ? depth : FLT_MAX;
+  const float s1 = d1 / ray.y;
+  const float s2 = d2 / ray.y;
+
+  // inbetween top and bottom is inconclusive
+  if (s1 * s2 < 0.0f)
+    return FLT_MAX;
+
+  const float s = fmaxf(s1, s2);
+
+  return (s >= eps) ? s : FLT_MAX;
 }
 
 __device__ float ocean_short_distance(const vec3 origin, const vec3 ray) {
-  const float d = device_scene.ocean.height - origin.y;
-  const float o = (d > 0.0f) ? (d + 3.0f * device_scene.ocean.amplitude) : d;
-  const float s = o / ray.y;
+  const float d1 = device_scene.ocean.height - origin.y;
+  const float d2 = d1 + device_scene.ocean.amplitude;
 
-  return (s >= eps) ? s : FLT_MAX;
+  const float s1 = d1 / ray.y;
+  const float s2 = d2 / ray.y;
+
+  // inbetween top and bottom is inconclusive
+  if (s1 * s2 < 0.0f)
+    return 0.0f;
+
+  return fabsf(fminf(s1, s2));
 }
 
 __device__ float ocean_intersection_distance(const vec3 origin, const vec3 ray, float max) {

--- a/src/cuda/ocean.cuh
+++ b/src/cuda/ocean.cuh
@@ -138,7 +138,7 @@ __device__ vec3 ocean_get_normal(vec3 p, const float diff) {
 
 __device__ float ocean_far_distance(const vec3 origin, const vec3 ray) {
   const float d1 = device_scene.ocean.height - origin.y;
-  const float d2 = d1 + device_scene.ocean.amplitude;
+  const float d2 = d1 + 3.0f * device_scene.ocean.amplitude;
 
   const float s1 = d1 / ray.y;
   const float s2 = d2 / ray.y;
@@ -154,7 +154,7 @@ __device__ float ocean_far_distance(const vec3 origin, const vec3 ray) {
 
 __device__ float ocean_short_distance(const vec3 origin, const vec3 ray) {
   const float d1 = device_scene.ocean.height - origin.y;
-  const float d2 = d1 + device_scene.ocean.amplitude;
+  const float d2 = d1 + 3.0f * device_scene.ocean.amplitude;
 
   const float s1 = d1 / ray.y;
   const float s2 = d2 / ray.y;

--- a/src/cuda/utils.cuh
+++ b/src/cuda/utils.cuh
@@ -128,6 +128,7 @@ struct DevicePointers {
   cudaTextureObject_t* albedo_atlas;
   cudaTextureObject_t* illuminance_atlas;
   cudaTextureObject_t* material_atlas;
+  cudaTextureObject_t* normal_atlas;
   cudaTextureObject_t* cloud_noise;
   LightSample* light_samples;
   LightEvalData* light_eval_data;

--- a/src/light.c
+++ b/src/light.c
@@ -106,7 +106,7 @@ static int contains_illumination(Triangle triangle, TextureRGBA tex) {
     max_e_2           = max(e_2_2, e_2_0);
   }
 
-  uint32_t* ptr = (uint32_t*) tex.data;
+  const uint32_t* ptr = (uint32_t*) tex.data;
 
   for (int j = min_y; j <= max_y; j++) {
     const int coordy = j % tex.height;
@@ -130,7 +130,7 @@ static int contains_illumination(Triangle triangle, TextureRGBA tex) {
   return 0;
 }
 
-void process_lights(Scene* scene, TextureRGBA* textures) {
+void lights_build_set_from_triangles(Scene* scene, TextureRGBA* textures) {
   bench_tic();
 
   Scene data = *scene;
@@ -144,7 +144,7 @@ void process_lights(Scene* scene, TextureRGBA* textures) {
 
     const uint16_t tex_index = data.texture_assignments[triangle.object_maps].illuminance_map;
 
-    if (tex_index != 0 && contains_illumination(triangle, textures[tex_index])) {
+    if (tex_index != TEXTURE_NONE && contains_illumination(triangle, textures[tex_index])) {
       const TriangleLight l      = {.vertex = triangle.vertex, .edge1 = triangle.edge1, .edge2 = triangle.edge2, .triangle_id = i};
       data.triangles[i].light_id = light_count;
       lights[light_count++]      = l;

--- a/src/lum.c
+++ b/src/lum.c
@@ -9,7 +9,7 @@
 static const int LINE_SIZE       = 4096;
 static const int CURRENT_VERSION = 4;
 
-static void parse_general_settings(General* general, Wavefront_Content* content, char* line) {
+static void parse_general_settings(General* general, WavefrontContent* content, char* line) {
   const uint64_t key = *((uint64_t*) line);
   char* value        = line + 9;
 
@@ -18,7 +18,7 @@ static void parse_general_settings(General* general, Wavefront_Content* content,
     case 4993446653056992589u: {
       char* source = (char*) malloc(LINE_SIZE);
       sscanf(value, "%s\n", source);
-      if (read_wavefront_file(source, content)) {
+      if (wavefront_read_file(content, source)) {
         error_message("Mesh file could not be loaded!");
       }
       if (general->mesh_files_count == general->mesh_files_length) {
@@ -513,9 +513,9 @@ int lum_validate_file(FILE* file) {
  * @param file File handle.
  * @param scene Scene instance.
  * @param general General instance.
- * @param content Wavefront_Content instance.
+ * @param content WavefrontContent instance.
  */
-void lum_parse_file(FILE* file, Scene* scene, General* general, Wavefront_Content* content) {
+void lum_parse_file(FILE* file, Scene* scene, General* general, WavefrontContent* content) {
   char* line = (char*) malloc(LINE_SIZE);
 
   while (1) {

--- a/src/lum.c
+++ b/src/lum.c
@@ -83,10 +83,6 @@ static void parse_material_settings(GlobalMaterial* material, char* line) {
     case 6866939734539981382u:
       sscanf(value, "%d\n", &material->fresnel);
       break;
-    /* BVHALPHA */
-    case 4704098099231479362u:
-      sscanf(value, "%d\n", &material->bvh_alpha_cutoff);
-      break;
     /* ALPHACUT */
     case 6076837219871509569u:
       sscanf(value, "%f\n", &material->alpha_cutoff);
@@ -650,8 +646,6 @@ void lum_write_file(FILE* file, RaytraceInstance* instance) {
   sprintf(line, "MATERIAL EMISSION %f\n", instance->scene_gpu.material.default_material.b);
   fputs(line, file);
   sprintf(line, "MATERIAL FRESNEL_ %d\n", instance->scene_gpu.material.fresnel);
-  fputs(line, file);
-  sprintf(line, "MATERIAL BVHALPHA %d\n", instance->scene_gpu.material.bvh_alpha_cutoff);
   fputs(line, file);
   sprintf(line, "MATERIAL ALPHACUT %f\n", instance->scene_gpu.material.alpha_cutoff);
   fputs(line, file);

--- a/src/png.c
+++ b/src/png.c
@@ -464,7 +464,7 @@ TextureRGBA load_texture_from_png(const char* filename) {
   FILE* file = fopen(filename, "rb");
 
   if (!file) {
-    error_message("File could not be opened!");
+    error_message("File %s could not be opened!", filename);
     return default_texture();
   }
 

--- a/src/raytrace.cu
+++ b/src/raytrace.cu
@@ -302,7 +302,7 @@ extern "C" void allocate_buffers(RaytraceInstance* instance) {
 
 extern "C" RaytraceInstance* init_raytracing(
   General general, DeviceBuffer* albedo_atlas, int albedo_atlas_length, DeviceBuffer* illuminance_atlas, int illuminance_atlas_length,
-  DeviceBuffer* material_atlas, int material_atlas_length, Scene scene) {
+  DeviceBuffer* material_atlas, int material_atlas_length, DeviceBuffer* normal_atlas, int normal_atlas_length, Scene scene) {
   RaytraceInstance* instance = (RaytraceInstance*) malloc(sizeof(RaytraceInstance));
   memset(instance, 0, sizeof(RaytraceInstance));
 
@@ -331,10 +331,12 @@ extern "C" RaytraceInstance* init_raytracing(
   instance->albedo_atlas      = albedo_atlas;
   instance->illuminance_atlas = illuminance_atlas;
   instance->material_atlas    = material_atlas;
+  instance->normal_atlas      = normal_atlas;
 
   instance->albedo_atlas_length      = albedo_atlas_length;
   instance->illuminance_atlas_length = illuminance_atlas_length;
   instance->material_atlas_length    = material_atlas_length;
+  instance->normal_atlas_length      = normal_atlas_length;
 
   instance->scene_gpu          = scene;
   instance->settings           = general;

--- a/src/raytrace.cu
+++ b/src/raytrace.cu
@@ -767,10 +767,10 @@ extern "C" void update_device_pointers(RaytraceInstance* instance) {
   ptrs.light_records        = (RGBAhalf*) device_buffer_get_pointer(instance->light_records);
   ptrs.bounce_records       = (RGBAhalf*) device_buffer_get_pointer(instance->bounce_records);
   ptrs.buffer_8bit          = (XRGB8*) device_buffer_get_pointer(instance->buffer_8bit);
-  ptrs.albedo_atlas         = (cudaTextureObject_t*) device_buffer_get_pointer(instance->tex_atlas.albedo_atlas);
-  ptrs.illuminance_atlas    = (cudaTextureObject_t*) device_buffer_get_pointer(instance->tex_atlas.illuminance_atlas);
-  ptrs.material_atlas       = (cudaTextureObject_t*) device_buffer_get_pointer(instance->tex_atlas.material_atlas);
-  ptrs.normal_atlas         = (cudaTextureObject_t*) device_buffer_get_pointer(instance->tex_atlas.normal_atlas);
+  ptrs.albedo_atlas         = (cudaTextureObject_t*) device_buffer_get_pointer(instance->tex_atlas.albedo);
+  ptrs.illuminance_atlas    = (cudaTextureObject_t*) device_buffer_get_pointer(instance->tex_atlas.illuminance);
+  ptrs.material_atlas       = (cudaTextureObject_t*) device_buffer_get_pointer(instance->tex_atlas.material);
+  ptrs.normal_atlas         = (cudaTextureObject_t*) device_buffer_get_pointer(instance->tex_atlas.normal);
   ptrs.cloud_noise          = (cudaTextureObject_t*) device_buffer_get_pointer(instance->cloud_noise);
   ptrs.randoms              = (curandStateXORWOW_t*) device_buffer_get_pointer(instance->randoms);
   ptrs.raydir_buffer        = (vec3*) device_buffer_get_pointer(instance->raydir_buffer);

--- a/src/raytrace.cu
+++ b/src/raytrace.cu
@@ -300,9 +300,7 @@ extern "C" void allocate_buffers(RaytraceInstance* instance) {
   cudaMemset(device_buffer_get_pointer(instance->trace_result_buffer), 0, sizeof(TraceResult) * amount);
 }
 
-extern "C" RaytraceInstance* init_raytracing(
-  General general, DeviceBuffer* albedo_atlas, int albedo_atlas_length, DeviceBuffer* illuminance_atlas, int illuminance_atlas_length,
-  DeviceBuffer* material_atlas, int material_atlas_length, DeviceBuffer* normal_atlas, int normal_atlas_length, Scene scene) {
+extern "C" RaytraceInstance* init_raytracing(General general, TextureAtlas tex_atlas, Scene scene) {
   RaytraceInstance* instance = (RaytraceInstance*) malloc(sizeof(RaytraceInstance));
   memset(instance, 0, sizeof(RaytraceInstance));
 
@@ -328,15 +326,7 @@ extern "C" RaytraceInstance* init_raytracing(
   instance->denoiser        = general.denoiser;
   instance->reservoir_size  = general.reservoir_size;
 
-  instance->albedo_atlas      = albedo_atlas;
-  instance->illuminance_atlas = illuminance_atlas;
-  instance->material_atlas    = material_atlas;
-  instance->normal_atlas      = normal_atlas;
-
-  instance->albedo_atlas_length      = albedo_atlas_length;
-  instance->illuminance_atlas_length = illuminance_atlas_length;
-  instance->material_atlas_length    = material_atlas_length;
-  instance->normal_atlas_length      = normal_atlas_length;
+  instance->tex_atlas = tex_atlas;
 
   instance->scene_gpu          = scene;
   instance->settings           = general;
@@ -777,9 +767,10 @@ extern "C" void update_device_pointers(RaytraceInstance* instance) {
   ptrs.light_records        = (RGBAhalf*) device_buffer_get_pointer(instance->light_records);
   ptrs.bounce_records       = (RGBAhalf*) device_buffer_get_pointer(instance->bounce_records);
   ptrs.buffer_8bit          = (XRGB8*) device_buffer_get_pointer(instance->buffer_8bit);
-  ptrs.albedo_atlas         = (cudaTextureObject_t*) device_buffer_get_pointer(instance->albedo_atlas);
-  ptrs.illuminance_atlas    = (cudaTextureObject_t*) device_buffer_get_pointer(instance->illuminance_atlas);
-  ptrs.material_atlas       = (cudaTextureObject_t*) device_buffer_get_pointer(instance->material_atlas);
+  ptrs.albedo_atlas         = (cudaTextureObject_t*) device_buffer_get_pointer(instance->tex_atlas.albedo_atlas);
+  ptrs.illuminance_atlas    = (cudaTextureObject_t*) device_buffer_get_pointer(instance->tex_atlas.illuminance_atlas);
+  ptrs.material_atlas       = (cudaTextureObject_t*) device_buffer_get_pointer(instance->tex_atlas.material_atlas);
+  ptrs.normal_atlas         = (cudaTextureObject_t*) device_buffer_get_pointer(instance->tex_atlas.normal_atlas);
   ptrs.cloud_noise          = (cudaTextureObject_t*) device_buffer_get_pointer(instance->cloud_noise);
   ptrs.randoms              = (curandStateXORWOW_t*) device_buffer_get_pointer(instance->randoms);
   ptrs.raydir_buffer        = (vec3*) device_buffer_get_pointer(instance->raydir_buffer);

--- a/src/raytrace.cu
+++ b/src/raytrace.cu
@@ -511,12 +511,7 @@ static void execute_kernels(RaytraceInstance* instance, int type) {
 
   preprocess_trace_tasks<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>();
 
-  if (instance->scene_gpu.material.bvh_alpha_cutoff) {
-    process_trace_tasks_alpha_cutoff<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>();
-  }
-  else {
-    process_trace_tasks<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>();
-  }
+  process_trace_tasks<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>();
 
   if (instance->scene_gpu.ocean.active && type != TYPE_LIGHT) {
     ocean_depth_trace_tasks<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>();
@@ -559,12 +554,9 @@ static void execute_debug_kernels(RaytraceInstance* instance, int type) {
   bind_type(instance, type);
 
   preprocess_trace_tasks<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>();
-  if (instance->scene_gpu.material.bvh_alpha_cutoff) {
-    process_trace_tasks_alpha_cutoff<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>();
-  }
-  else {
-    process_trace_tasks<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>();
-  }
+
+  process_trace_tasks<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>();
+
   if (instance->scene_gpu.ocean.active && type != TYPE_LIGHT) {
     ocean_depth_trace_tasks<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>();
   }

--- a/src/scene.c
+++ b/src/scene.c
@@ -27,7 +27,6 @@ static Scene get_default_scene() {
   scene.material.default_material.g = 0.0f;
   scene.material.default_material.b = 1.0f;
   scene.material.fresnel            = FDEZ_AGUERA;
-  scene.material.bvh_alpha_cutoff   = 1;
   scene.material.alpha_cutoff       = 0.0f;
 
   scene.camera.pos.x                 = 0.0f;

--- a/src/scene.c
+++ b/src/scene.c
@@ -234,14 +234,17 @@ RaytraceInstance* load_scene(const char* filename) {
 
   process_lights(&scene, content.illuminance_maps);
 
-  DeviceBuffer* albedo_atlas      = cudatexture_allocate_to_buffer(content.albedo_maps, content.albedo_maps_length);
-  DeviceBuffer* illuminance_atlas = cudatexture_allocate_to_buffer(content.illuminance_maps, content.illuminance_maps_length);
-  DeviceBuffer* material_atlas    = cudatexture_allocate_to_buffer(content.material_maps, content.material_maps_length);
-  DeviceBuffer* normal_atlas      = cudatexture_allocate_to_buffer(content.normal_maps, content.normal_maps_length);
+  TextureAtlas tex_atlas = {
+    .albedo_atlas             = cudatexture_allocate_to_buffer(content.albedo_maps, content.albedo_maps_length),
+    .albedo_atlas_length      = content.albedo_maps_length,
+    .illuminance_atlas        = cudatexture_allocate_to_buffer(content.illuminance_maps, content.illuminance_maps_length),
+    .illuminance_atlas_length = content.illuminance_maps_length,
+    .material_atlas           = cudatexture_allocate_to_buffer(content.material_maps, content.material_maps_length),
+    .material_atlas_length    = content.material_maps_length,
+    .normal_atlas             = cudatexture_allocate_to_buffer(content.normal_maps, content.normal_maps_length),
+    .normal_atlas_length      = content.normal_maps_length};
 
-  RaytraceInstance* instance = init_raytracing(
-    general, albedo_atlas, content.albedo_maps_length, illuminance_atlas, content.illuminance_maps_length, material_atlas,
-    content.material_maps_length, normal_atlas, content.normal_maps_length, scene);
+  RaytraceInstance* instance = init_raytracing(general, tex_atlas, scene);
 
   free_wavefront_content(content);
   free_scene(scene);
@@ -269,14 +272,17 @@ RaytraceInstance* load_obj_as_scene(char* filename) {
 
   process_lights(&scene, content.illuminance_maps);
 
-  DeviceBuffer* albedo_atlas      = cudatexture_allocate_to_buffer(content.albedo_maps, content.albedo_maps_length);
-  DeviceBuffer* illuminance_atlas = cudatexture_allocate_to_buffer(content.illuminance_maps, content.illuminance_maps_length);
-  DeviceBuffer* material_atlas    = cudatexture_allocate_to_buffer(content.material_maps, content.material_maps_length);
-  DeviceBuffer* normal_atlas      = cudatexture_allocate_to_buffer(content.normal_maps, content.normal_maps_length);
+  TextureAtlas tex_atlas = {
+    .albedo_atlas             = cudatexture_allocate_to_buffer(content.albedo_maps, content.albedo_maps_length),
+    .albedo_atlas_length      = content.albedo_maps_length,
+    .illuminance_atlas        = cudatexture_allocate_to_buffer(content.illuminance_maps, content.illuminance_maps_length),
+    .illuminance_atlas_length = content.illuminance_maps_length,
+    .material_atlas           = cudatexture_allocate_to_buffer(content.material_maps, content.material_maps_length),
+    .material_atlas_length    = content.material_maps_length,
+    .normal_atlas             = cudatexture_allocate_to_buffer(content.normal_maps, content.normal_maps_length),
+    .normal_atlas_length      = content.normal_maps_length};
 
-  RaytraceInstance* instance = init_raytracing(
-    general, albedo_atlas, content.albedo_maps_length, illuminance_atlas, content.illuminance_maps_length, material_atlas,
-    content.material_maps_length, normal_atlas, content.normal_maps_length, scene);
+  RaytraceInstance* instance = init_raytracing(general, tex_atlas, scene);
 
   free_wavefront_content(content);
   free_scene(scene);
@@ -300,9 +306,10 @@ void serialize_scene(RaytraceInstance* instance) {
 }
 
 void free_atlases(RaytraceInstance* instance) {
-  cudatexture_free_buffer(instance->albedo_atlas, instance->albedo_atlas_length);
-  cudatexture_free_buffer(instance->illuminance_atlas, instance->illuminance_atlas_length);
-  cudatexture_free_buffer(instance->material_atlas, instance->material_atlas_length);
+  cudatexture_free_buffer(instance->tex_atlas.albedo_atlas, instance->tex_atlas.albedo_atlas_length);
+  cudatexture_free_buffer(instance->tex_atlas.illuminance_atlas, instance->tex_atlas.illuminance_atlas_length);
+  cudatexture_free_buffer(instance->tex_atlas.material_atlas, instance->tex_atlas.material_atlas_length);
+  cudatexture_free_buffer(instance->tex_atlas.normal_atlas, instance->tex_atlas.normal_atlas_length);
 }
 
 void free_strings(RaytraceInstance* instance) {

--- a/src/scene.c
+++ b/src/scene.c
@@ -232,7 +232,7 @@ RaytraceInstance* scene_load_lum(const char* filename) {
 
   scene_create_from_wavefront(scene, content);
 
-  process_lights(scene, content->illuminance_maps);
+  lights_build_set_from_triangles(scene, content->illuminance_maps);
 
   TextureAtlas tex_atlas = {
     .albedo             = cudatexture_allocate_to_buffer(content->albedo_maps, content->albedo_maps_length),
@@ -274,7 +274,7 @@ RaytraceInstance* scene_load_obj(char* filename) {
 
   scene_create_from_wavefront(scene, content);
 
-  process_lights(scene, content->illuminance_maps);
+  lights_build_set_from_triangles(scene, content->illuminance_maps);
 
   TextureAtlas tex_atlas = {
     .albedo             = cudatexture_allocate_to_buffer(content->albedo_maps, content->albedo_maps_length),

--- a/src/scene.c
+++ b/src/scene.c
@@ -235,14 +235,14 @@ RaytraceInstance* load_scene(const char* filename) {
   process_lights(&scene, content.illuminance_maps);
 
   TextureAtlas tex_atlas = {
-    .albedo_atlas             = cudatexture_allocate_to_buffer(content.albedo_maps, content.albedo_maps_length),
-    .albedo_atlas_length      = content.albedo_maps_length,
-    .illuminance_atlas        = cudatexture_allocate_to_buffer(content.illuminance_maps, content.illuminance_maps_length),
-    .illuminance_atlas_length = content.illuminance_maps_length,
-    .material_atlas           = cudatexture_allocate_to_buffer(content.material_maps, content.material_maps_length),
-    .material_atlas_length    = content.material_maps_length,
-    .normal_atlas             = cudatexture_allocate_to_buffer(content.normal_maps, content.normal_maps_length),
-    .normal_atlas_length      = content.normal_maps_length};
+    .albedo             = cudatexture_allocate_to_buffer(content.albedo_maps, content.albedo_maps_length),
+    .albedo_length      = content.albedo_maps_length,
+    .illuminance        = cudatexture_allocate_to_buffer(content.illuminance_maps, content.illuminance_maps_length),
+    .illuminance_length = content.illuminance_maps_length,
+    .material           = cudatexture_allocate_to_buffer(content.material_maps, content.material_maps_length),
+    .material_length    = content.material_maps_length,
+    .normal             = cudatexture_allocate_to_buffer(content.normal_maps, content.normal_maps_length),
+    .normal_length      = content.normal_maps_length};
 
   RaytraceInstance* instance = init_raytracing(general, tex_atlas, scene);
 
@@ -273,14 +273,14 @@ RaytraceInstance* load_obj_as_scene(char* filename) {
   process_lights(&scene, content.illuminance_maps);
 
   TextureAtlas tex_atlas = {
-    .albedo_atlas             = cudatexture_allocate_to_buffer(content.albedo_maps, content.albedo_maps_length),
-    .albedo_atlas_length      = content.albedo_maps_length,
-    .illuminance_atlas        = cudatexture_allocate_to_buffer(content.illuminance_maps, content.illuminance_maps_length),
-    .illuminance_atlas_length = content.illuminance_maps_length,
-    .material_atlas           = cudatexture_allocate_to_buffer(content.material_maps, content.material_maps_length),
-    .material_atlas_length    = content.material_maps_length,
-    .normal_atlas             = cudatexture_allocate_to_buffer(content.normal_maps, content.normal_maps_length),
-    .normal_atlas_length      = content.normal_maps_length};
+    .albedo             = cudatexture_allocate_to_buffer(content.albedo_maps, content.albedo_maps_length),
+    .albedo_length      = content.albedo_maps_length,
+    .illuminance        = cudatexture_allocate_to_buffer(content.illuminance_maps, content.illuminance_maps_length),
+    .illuminance_length = content.illuminance_maps_length,
+    .material           = cudatexture_allocate_to_buffer(content.material_maps, content.material_maps_length),
+    .material_length    = content.material_maps_length,
+    .normal             = cudatexture_allocate_to_buffer(content.normal_maps, content.normal_maps_length),
+    .normal_length      = content.normal_maps_length};
 
   RaytraceInstance* instance = init_raytracing(general, tex_atlas, scene);
 
@@ -306,10 +306,10 @@ void serialize_scene(RaytraceInstance* instance) {
 }
 
 void free_atlases(RaytraceInstance* instance) {
-  cudatexture_free_buffer(instance->tex_atlas.albedo_atlas, instance->tex_atlas.albedo_atlas_length);
-  cudatexture_free_buffer(instance->tex_atlas.illuminance_atlas, instance->tex_atlas.illuminance_atlas_length);
-  cudatexture_free_buffer(instance->tex_atlas.material_atlas, instance->tex_atlas.material_atlas_length);
-  cudatexture_free_buffer(instance->tex_atlas.normal_atlas, instance->tex_atlas.normal_atlas_length);
+  cudatexture_free_buffer(instance->tex_atlas.albedo, instance->tex_atlas.albedo_length);
+  cudatexture_free_buffer(instance->tex_atlas.illuminance, instance->tex_atlas.illuminance_length);
+  cudatexture_free_buffer(instance->tex_atlas.material, instance->tex_atlas.material_length);
+  cudatexture_free_buffer(instance->tex_atlas.normal, instance->tex_atlas.normal_length);
 }
 
 void free_strings(RaytraceInstance* instance) {

--- a/src/scene.c
+++ b/src/scene.c
@@ -17,142 +17,140 @@
 
 static const int LINE_SIZE = 4096;
 
-static Scene get_default_scene() {
-  Scene scene;
+void scene_init(Scene** _scene) {
+  Scene* scene = calloc(1, sizeof(Scene));
 
-  memset(&scene, 0, sizeof(Scene));
+  scene->material.lights_active      = 0;
+  scene->material.default_material.r = 0.3f;
+  scene->material.default_material.g = 0.0f;
+  scene->material.default_material.b = 1.0f;
+  scene->material.fresnel            = FDEZ_AGUERA;
+  scene->material.alpha_cutoff       = 0.0f;
 
-  scene.material.lights_active      = 0;
-  scene.material.default_material.r = 0.3f;
-  scene.material.default_material.g = 0.0f;
-  scene.material.default_material.b = 1.0f;
-  scene.material.fresnel            = FDEZ_AGUERA;
-  scene.material.alpha_cutoff       = 0.0f;
+  scene->camera.pos.x                 = 0.0f;
+  scene->camera.pos.y                 = 0.0f;
+  scene->camera.pos.z                 = 0.0f;
+  scene->camera.rotation.x            = 0.0f;
+  scene->camera.rotation.y            = 0.0f;
+  scene->camera.rotation.z            = 0.0f;
+  scene->camera.fov                   = 1.0f;
+  scene->camera.focal_length          = 1.0f;
+  scene->camera.aperture_size         = 0.00f;
+  scene->camera.exposure              = 1.0f;
+  scene->camera.auto_exposure         = 1;
+  scene->camera.bloom                 = 1;
+  scene->camera.bloom_strength        = 1.0f;
+  scene->camera.bloom_threshold       = 1.0f;
+  scene->camera.dithering             = 1;
+  scene->camera.far_clip_distance     = 50000.0f;
+  scene->camera.tonemap               = TONEMAP_ACES;
+  scene->camera.filter                = FILTER_NONE;
+  scene->camera.wasd_speed            = 1.0f;
+  scene->camera.mouse_speed           = 1.0f;
+  scene->camera.smooth_movement       = 0;
+  scene->camera.smoothing_factor      = 0.1f;
+  scene->camera.temporal_blend_factor = 0.15f;
+  scene->camera.purkinje              = 1;
+  scene->camera.purkinje_kappa1       = 0.2f;
+  scene->camera.purkinje_kappa2       = 0.29f;
 
-  scene.camera.pos.x                 = 0.0f;
-  scene.camera.pos.y                 = 0.0f;
-  scene.camera.pos.z                 = 0.0f;
-  scene.camera.rotation.x            = 0.0f;
-  scene.camera.rotation.y            = 0.0f;
-  scene.camera.rotation.z            = 0.0f;
-  scene.camera.fov                   = 1.0f;
-  scene.camera.focal_length          = 1.0f;
-  scene.camera.aperture_size         = 0.00f;
-  scene.camera.exposure              = 1.0f;
-  scene.camera.auto_exposure         = 1;
-  scene.camera.bloom                 = 1;
-  scene.camera.bloom_strength        = 1.0f;
-  scene.camera.bloom_threshold       = 1.0f;
-  scene.camera.dithering             = 1;
-  scene.camera.far_clip_distance     = 50000.0f;
-  scene.camera.tonemap               = TONEMAP_ACES;
-  scene.camera.filter                = FILTER_NONE;
-  scene.camera.wasd_speed            = 1.0f;
-  scene.camera.mouse_speed           = 1.0f;
-  scene.camera.smooth_movement       = 0;
-  scene.camera.smoothing_factor      = 0.1f;
-  scene.camera.temporal_blend_factor = 0.15f;
-  scene.camera.purkinje              = 1;
-  scene.camera.purkinje_kappa1       = 0.2f;
-  scene.camera.purkinje_kappa2       = 0.29f;
+  scene->ocean.active              = 0;
+  scene->ocean.emissive            = 0;
+  scene->ocean.update              = 0;
+  scene->ocean.height              = 0.0f;
+  scene->ocean.amplitude           = 0.2f;
+  scene->ocean.frequency           = 0.12f;
+  scene->ocean.choppyness          = 4.0f;
+  scene->ocean.speed               = 1.0f;
+  scene->ocean.time                = 0.0f;
+  scene->ocean.albedo.r            = 0.0f;
+  scene->ocean.albedo.g            = 0.0f;
+  scene->ocean.albedo.b            = 0.0f;
+  scene->ocean.albedo.a            = 0.9f;
+  scene->ocean.refractive_index    = 1.333f;
+  scene->ocean.anisotropy          = 0.0f;
+  scene->ocean.scattering.r        = 0.0f;
+  scene->ocean.scattering.g        = 0.2f;
+  scene->ocean.scattering.b        = 1.0f;
+  scene->ocean.absorption.r        = 1.0f;
+  scene->ocean.absorption.g        = 0.15f;
+  scene->ocean.absorption.b        = 0.01f;
+  scene->ocean.pollution           = 0.5f;
+  scene->ocean.absorption_strength = 1.0f;
 
-  scene.ocean.active              = 0;
-  scene.ocean.emissive            = 0;
-  scene.ocean.update              = 0;
-  scene.ocean.height              = 0.0f;
-  scene.ocean.amplitude           = 0.2f;
-  scene.ocean.frequency           = 0.12f;
-  scene.ocean.choppyness          = 4.0f;
-  scene.ocean.speed               = 1.0f;
-  scene.ocean.time                = 0.0f;
-  scene.ocean.albedo.r            = 0.0f;
-  scene.ocean.albedo.g            = 0.0f;
-  scene.ocean.albedo.b            = 0.0f;
-  scene.ocean.albedo.a            = 0.9f;
-  scene.ocean.refractive_index    = 1.333f;
-  scene.ocean.anisotropy          = 0.0f;
-  scene.ocean.scattering.r        = 0.0f;
-  scene.ocean.scattering.g        = 0.2f;
-  scene.ocean.scattering.b        = 1.0f;
-  scene.ocean.absorption.r        = 1.0f;
-  scene.ocean.absorption.g        = 0.15f;
-  scene.ocean.absorption.b        = 0.01f;
-  scene.ocean.pollution           = 0.5f;
-  scene.ocean.absorption_strength = 1.0f;
+  scene->toy.active           = 0;
+  scene->toy.emissive         = 0;
+  scene->toy.shape            = TOY_SPHERE;
+  scene->toy.position.x       = 0.0f;
+  scene->toy.position.y       = 10.0f;
+  scene->toy.position.z       = 0.0f;
+  scene->toy.rotation.x       = 0.0f;
+  scene->toy.rotation.y       = 0.0f;
+  scene->toy.rotation.z       = 0.0f;
+  scene->toy.scale            = 1.0f;
+  scene->toy.refractive_index = 1.0f;
+  scene->toy.albedo.r         = 0.9f;
+  scene->toy.albedo.g         = 0.9f;
+  scene->toy.albedo.b         = 0.9f;
+  scene->toy.albedo.a         = 1.0f;
+  scene->toy.material.r       = 0.3f;
+  scene->toy.material.g       = 0.0f;
+  scene->toy.material.b       = 1.0f;
+  scene->toy.material.a       = 0.0f;
+  scene->toy.emission.r       = 0.0f;
+  scene->toy.emission.g       = 0.0f;
+  scene->toy.emission.b       = 0.0f;
+  scene->toy.emission.a       = 0.0f;
+  scene->toy.flashlight_mode  = 0;
 
-  scene.toy.active           = 0;
-  scene.toy.emissive         = 0;
-  scene.toy.shape            = TOY_SPHERE;
-  scene.toy.position.x       = 0.0f;
-  scene.toy.position.y       = 10.0f;
-  scene.toy.position.z       = 0.0f;
-  scene.toy.rotation.x       = 0.0f;
-  scene.toy.rotation.y       = 0.0f;
-  scene.toy.rotation.z       = 0.0f;
-  scene.toy.scale            = 1.0f;
-  scene.toy.refractive_index = 1.0f;
-  scene.toy.albedo.r         = 0.9f;
-  scene.toy.albedo.g         = 0.9f;
-  scene.toy.albedo.b         = 0.9f;
-  scene.toy.albedo.a         = 1.0f;
-  scene.toy.material.r       = 0.3f;
-  scene.toy.material.g       = 0.0f;
-  scene.toy.material.b       = 1.0f;
-  scene.toy.material.a       = 0.0f;
-  scene.toy.emission.r       = 0.0f;
-  scene.toy.emission.g       = 0.0f;
-  scene.toy.emission.b       = 0.0f;
-  scene.toy.emission.a       = 0.0f;
-  scene.toy.flashlight_mode  = 0;
+  scene->sky.geometry_offset.x         = 0.0f;
+  scene->sky.geometry_offset.y         = 0.1f;
+  scene->sky.geometry_offset.z         = 0.0f;
+  scene->sky.sun_color.r               = 1.0f;
+  scene->sky.sun_color.g               = 0.9f;
+  scene->sky.sun_color.b               = 0.8f;
+  scene->sky.altitude                  = 0.5f;
+  scene->sky.azimuth                   = 3.141f;
+  scene->sky.moon_altitude             = -0.5f;
+  scene->sky.moon_azimuth              = 0.0f;
+  scene->sky.moon_albedo               = 0.12f;
+  scene->sky.sun_strength              = 15000.0f;
+  scene->sky.base_density              = 1.0f;
+  scene->sky.steps                     = 8;
+  scene->sky.shadow_steps              = 8;
+  scene->sky.ozone_absorption          = 1;
+  scene->sky.stars_seed                = 0;
+  scene->sky.stars_intensity           = 1.0f;
+  scene->sky.settings_stars_count      = 10000;
+  scene->sky.cloud.active              = 0;
+  scene->sky.cloud.initialized         = 0;
+  scene->sky.cloud.seed                = 1;
+  scene->sky.cloud.offset_x            = 0.0f;
+  scene->sky.cloud.offset_z            = 0.0f;
+  scene->sky.cloud.height_max          = 4000.0f;
+  scene->sky.cloud.height_min          = 1500.0f;
+  scene->sky.cloud.noise_shape_scale   = 1.0f;
+  scene->sky.cloud.noise_detail_scale  = 1.0f;
+  scene->sky.cloud.noise_weather_scale = 1.0f;
+  scene->sky.cloud.noise_curl_scale    = 1.0f;
+  scene->sky.cloud.coverage            = 1.0f;
+  scene->sky.cloud.anvil               = 0.0f;
+  scene->sky.cloud.coverage_min        = 1.05f;
+  scene->sky.cloud.forward_scattering  = 0.8f;
+  scene->sky.cloud.backward_scattering = -0.2f;
+  scene->sky.cloud.lobe_lerp           = 0.5f;
+  scene->sky.cloud.wetness             = 0.0f;
+  scene->sky.cloud.powder              = 0.5f;
+  scene->sky.cloud.shadow_steps        = 16;
+  scene->sky.cloud.density             = 1.0f;
 
-  scene.sky.geometry_offset.x         = 0.0f;
-  scene.sky.geometry_offset.y         = 0.1f;
-  scene.sky.geometry_offset.z         = 0.0f;
-  scene.sky.sun_color.r               = 1.0f;
-  scene.sky.sun_color.g               = 0.9f;
-  scene.sky.sun_color.b               = 0.8f;
-  scene.sky.altitude                  = 0.5f;
-  scene.sky.azimuth                   = 3.141f;
-  scene.sky.moon_altitude             = -0.5f;
-  scene.sky.moon_azimuth              = 0.0f;
-  scene.sky.moon_albedo               = 0.12f;
-  scene.sky.sun_strength              = 15000.0f;
-  scene.sky.base_density              = 1.0f;
-  scene.sky.steps                     = 8;
-  scene.sky.shadow_steps              = 8;
-  scene.sky.ozone_absorption          = 1;
-  scene.sky.stars_seed                = 0;
-  scene.sky.stars_intensity           = 1.0f;
-  scene.sky.settings_stars_count      = 10000;
-  scene.sky.cloud.active              = 0;
-  scene.sky.cloud.initialized         = 0;
-  scene.sky.cloud.seed                = 1;
-  scene.sky.cloud.offset_x            = 0.0f;
-  scene.sky.cloud.offset_z            = 0.0f;
-  scene.sky.cloud.height_max          = 4000.0f;
-  scene.sky.cloud.height_min          = 1500.0f;
-  scene.sky.cloud.noise_shape_scale   = 1.0f;
-  scene.sky.cloud.noise_detail_scale  = 1.0f;
-  scene.sky.cloud.noise_weather_scale = 1.0f;
-  scene.sky.cloud.noise_curl_scale    = 1.0f;
-  scene.sky.cloud.coverage            = 1.0f;
-  scene.sky.cloud.anvil               = 0.0f;
-  scene.sky.cloud.coverage_min        = 1.05f;
-  scene.sky.cloud.forward_scattering  = 0.8f;
-  scene.sky.cloud.backward_scattering = -0.2f;
-  scene.sky.cloud.lobe_lerp           = 0.5f;
-  scene.sky.cloud.wetness             = 0.0f;
-  scene.sky.cloud.powder              = 0.5f;
-  scene.sky.cloud.shadow_steps        = 16;
-  scene.sky.cloud.density             = 1.0f;
+  scene->fog.active     = 0;
+  scene->fog.density    = 1.0f;
+  scene->fog.anisotropy = 0.0f;
+  scene->fog.height     = 500.0f;
+  scene->fog.dist       = 500.0f;
 
-  scene.fog.active     = 0;
-  scene.fog.density    = 1.0f;
-  scene.fog.anisotropy = 0.0f;
-  scene.fog.height     = 500.0f;
-  scene.fog.dist       = 500.0f;
-
-  return scene;
+  *_scene = scene;
 }
 
 static General get_default_settings() {
@@ -171,7 +169,7 @@ static General get_default_settings() {
   return general;
 }
 
-static void convert_wavefront_to_internal(WavefrontContent* content, Scene* scene) {
+void scene_create_from_wavefront(Scene* scene, WavefrontContent* content) {
   scene->triangles_length = wavefront_convert_content(content, &scene->triangles);
 
   Node2* initial_nodes = build_bvh_structure(&scene->triangles, &scene->triangles_length, &scene->nodes_length);
@@ -203,7 +201,7 @@ static void convert_wavefront_to_internal(WavefrontContent* content, Scene* scen
   }
 }
 
-RaytraceInstance* load_scene(const char* filename) {
+RaytraceInstance* scene_load_lum(const char* filename) {
   FILE* file = fopen(filename, "rb");
 
   if (!file) {
@@ -216,7 +214,9 @@ RaytraceInstance* load_scene(const char* filename) {
     return (RaytraceInstance*) 0;
   }
 
-  Scene scene     = get_default_scene();
+  Scene* scene;
+  scene_init(&scene);
+
   General general = get_default_settings();
 
   strcpy(general.output_path, "output");
@@ -224,15 +224,15 @@ RaytraceInstance* load_scene(const char* filename) {
   WavefrontContent* content;
   wavefront_init(&content);
 
-  lum_parse_file(file, &scene, &general, content);
+  lum_parse_file(file, scene, &general, content);
 
   fclose(file);
 
   assert(general.mesh_files_count, "No mesh files where loaded.", 1);
 
-  convert_wavefront_to_internal(content, &scene);
+  scene_create_from_wavefront(scene, content);
 
-  process_lights(&scene, content->illuminance_maps);
+  process_lights(scene, content->illuminance_maps);
 
   TextureAtlas tex_atlas = {
     .albedo             = cudatexture_allocate_to_buffer(content->albedo_maps, content->albedo_maps_length),
@@ -244,18 +244,21 @@ RaytraceInstance* load_scene(const char* filename) {
     .normal             = cudatexture_allocate_to_buffer(content->normal_maps, content->normal_maps_length),
     .normal_length      = content->normal_maps_length};
 
-  RaytraceInstance* instance = init_raytracing(general, tex_atlas, scene);
+  RaytraceInstance* instance;
+  raytracing_init(&instance, general, tex_atlas, scene);
 
   wavefront_clear(&content);
-  free_scene(scene);
+  scene_clear(&scene);
 
   generate_stars(instance);
 
   return instance;
 }
 
-RaytraceInstance* load_obj_as_scene(char* filename) {
-  Scene scene     = get_default_scene();
+RaytraceInstance* scene_load_obj(char* filename) {
+  Scene* scene;
+  scene_init(&scene);
+
   General general = get_default_settings();
 
   general.mesh_files[0] = malloc(LINE_SIZE);
@@ -269,9 +272,9 @@ RaytraceInstance* load_obj_as_scene(char* filename) {
 
   general.mesh_files[general.mesh_files_count++] = filename;
 
-  convert_wavefront_to_internal(content, &scene);
+  scene_create_from_wavefront(scene, content);
 
-  process_lights(&scene, content->illuminance_maps);
+  process_lights(scene, content->illuminance_maps);
 
   TextureAtlas tex_atlas = {
     .albedo             = cudatexture_allocate_to_buffer(content->albedo_maps, content->albedo_maps_length),
@@ -283,17 +286,18 @@ RaytraceInstance* load_obj_as_scene(char* filename) {
     .normal             = cudatexture_allocate_to_buffer(content->normal_maps, content->normal_maps_length),
     .normal_length      = content->normal_maps_length};
 
-  RaytraceInstance* instance = init_raytracing(general, tex_atlas, scene);
+  RaytraceInstance* instance;
+  raytracing_init(&instance, general, tex_atlas, scene);
 
   wavefront_clear(&content);
-  free_scene(scene);
+  scene_clear(&scene);
 
   generate_stars(instance);
 
   return instance;
 }
 
-void serialize_scene(RaytraceInstance* instance) {
+void scene_serialize(RaytraceInstance* instance) {
   FILE* file = fopen("generated.lum", "wb");
 
   if (!file) {
@@ -321,10 +325,17 @@ void free_strings(RaytraceInstance* instance) {
   free(instance->settings.output_path);
 }
 
-void free_scene(Scene scene) {
-  free(scene.triangles);
-  free(scene.traversal_triangles);
-  free(scene.nodes);
-  free(scene.triangle_lights);
-  free(scene.texture_assignments);
+void scene_clear(Scene** scene) {
+  if (!scene) {
+    error_message("Scene is NULL.");
+    return;
+  }
+
+  free((*scene)->triangles);
+  free((*scene)->traversal_triangles);
+  free((*scene)->nodes);
+  free((*scene)->triangle_lights);
+  free((*scene)->texture_assignments);
+
+  free(*scene);
 }

--- a/src/scene.c
+++ b/src/scene.c
@@ -237,10 +237,11 @@ RaytraceInstance* load_scene(const char* filename) {
   DeviceBuffer* albedo_atlas      = cudatexture_allocate_to_buffer(content.albedo_maps, content.albedo_maps_length);
   DeviceBuffer* illuminance_atlas = cudatexture_allocate_to_buffer(content.illuminance_maps, content.illuminance_maps_length);
   DeviceBuffer* material_atlas    = cudatexture_allocate_to_buffer(content.material_maps, content.material_maps_length);
+  DeviceBuffer* normal_atlas      = cudatexture_allocate_to_buffer(content.normal_maps, content.normal_maps_length);
 
   RaytraceInstance* instance = init_raytracing(
     general, albedo_atlas, content.albedo_maps_length, illuminance_atlas, content.illuminance_maps_length, material_atlas,
-    content.material_maps_length, scene);
+    content.material_maps_length, normal_atlas, content.normal_maps_length, scene);
 
   free_wavefront_content(content);
   free_scene(scene);
@@ -271,10 +272,11 @@ RaytraceInstance* load_obj_as_scene(char* filename) {
   DeviceBuffer* albedo_atlas      = cudatexture_allocate_to_buffer(content.albedo_maps, content.albedo_maps_length);
   DeviceBuffer* illuminance_atlas = cudatexture_allocate_to_buffer(content.illuminance_maps, content.illuminance_maps_length);
   DeviceBuffer* material_atlas    = cudatexture_allocate_to_buffer(content.material_maps, content.material_maps_length);
+  DeviceBuffer* normal_atlas      = cudatexture_allocate_to_buffer(content.normal_maps, content.normal_maps_length);
 
   RaytraceInstance* instance = init_raytracing(
     general, albedo_atlas, content.albedo_maps_length, illuminance_atlas, content.illuminance_maps_length, material_atlas,
-    content.material_maps_length, scene);
+    content.material_maps_length, normal_atlas, content.normal_maps_length, scene);
 
   free_wavefront_content(content);
   free_scene(scene);

--- a/src/wavefront.c
+++ b/src/wavefront.c
@@ -16,115 +16,121 @@
 #define LINE_SIZE 4096
 #define READ_BUFFER_SIZE 262144  // 256kb
 
-Wavefront_Content create_wavefront_content() {
-  Wavefront_Content content;
-  content.vertices         = malloc(sizeof(Wavefront_Vertex) * 1);
-  content.vertices_length  = 0;
-  content.normals          = malloc(sizeof(Wavefront_Normal) * 1);
-  content.normals_length   = 0;
-  content.uvs              = malloc(sizeof(Wavefront_UV) * 1);
-  content.uvs_length       = 0;
-  content.triangles        = malloc(sizeof(Wavefront_Triangle) * 1);
-  content.triangles_length = 0;
-  content.materials        = malloc(sizeof(Wavefront_Material) * 1);
-  content.materials_length = 1;
+void wavefront_init(WavefrontContent** content) {
+  *content = malloc(sizeof(WavefrontContent));
 
-  content.materials[0].hash                = 0;
-  content.materials[0].albedo_texture      = 0;
-  content.materials[0].illuminance_texture = 0;
-  content.materials[0].material_texture    = 0;
-  content.materials[0].normal_texture      = 0;
+  (*content)->vertices         = malloc(sizeof(WavefrontVertex) * 1);
+  (*content)->vertices_length  = 0;
+  (*content)->normals          = malloc(sizeof(WavefrontNormal) * 1);
+  (*content)->normals_length   = 0;
+  (*content)->uvs              = malloc(sizeof(WavefrontUV) * 1);
+  (*content)->uvs_length       = 0;
+  (*content)->triangles        = malloc(sizeof(WavefrontTriangle) * 1);
+  (*content)->triangles_length = 0;
+  (*content)->materials        = malloc(sizeof(WavefrontMaterial) * 1);
+  (*content)->materials_length = 1;
 
-  content.albedo_maps             = (TextureRGBA*) malloc(sizeof(TextureRGBA) * 1);
-  content.albedo_maps_length      = 1;
-  content.illuminance_maps        = (TextureRGBA*) malloc(sizeof(TextureRGBA) * 1);
-  content.illuminance_maps_length = 1;
-  content.material_maps           = (TextureRGBA*) malloc(sizeof(TextureRGBA) * 1);
-  content.material_maps_length    = 1;
-  content.normal_maps             = (TextureRGBA*) malloc(sizeof(TextureRGBA) * 1);
-  content.normal_maps_length      = 1;
+  (*content)->materials[0].hash                = 0;
+  (*content)->materials[0].albedo_texture      = 0;
+  (*content)->materials[0].illuminance_texture = 0;
+  (*content)->materials[0].material_texture    = 0;
+  (*content)->materials[0].normal_texture      = 0;
+
+  (*content)->albedo_maps             = (TextureRGBA*) malloc(sizeof(TextureRGBA) * 1);
+  (*content)->albedo_maps_length      = 1;
+  (*content)->illuminance_maps        = (TextureRGBA*) malloc(sizeof(TextureRGBA) * 1);
+  (*content)->illuminance_maps_length = 1;
+  (*content)->material_maps           = (TextureRGBA*) malloc(sizeof(TextureRGBA) * 1);
+  (*content)->material_maps_length    = 1;
+  (*content)->normal_maps             = (TextureRGBA*) malloc(sizeof(TextureRGBA) * 1);
+  (*content)->normal_maps_length      = 1;
 
   RGBA8 default_albedo   = {.r = 230, .g = 230, .b = 230, .a = 255};
   RGBA8 default_material = {.r = 50, .g = 0, .b = 1, .a = 255};
   RGBA8 default_normal   = {.r = 127, .g = 127, .b = 255, .a = 0};
 
-  content.albedo_maps[0].width      = 4;
-  content.albedo_maps[0].height     = 4;
-  content.albedo_maps[0].depth      = 1;
-  content.albedo_maps[0].pitch      = 4;
-  content.albedo_maps[0].type       = TexDataUINT8;
-  content.albedo_maps[0].gpu        = 0;
-  content.albedo_maps[0].volume_tex = 0;
-  content.albedo_maps[0].data       = (RGBA8*) malloc(sizeof(RGBA8) * 16);
+  (*content)->albedo_maps[0].width      = 4;
+  (*content)->albedo_maps[0].height     = 4;
+  (*content)->albedo_maps[0].depth      = 1;
+  (*content)->albedo_maps[0].pitch      = 4;
+  (*content)->albedo_maps[0].type       = TexDataUINT8;
+  (*content)->albedo_maps[0].gpu        = 0;
+  (*content)->albedo_maps[0].volume_tex = 0;
+  (*content)->albedo_maps[0].data       = (RGBA8*) malloc(sizeof(RGBA8) * 16);
   for (int i = 0; i < 16; i++) {
-    ((RGBA8*) content.albedo_maps[0].data)[i] = default_albedo;
+    ((RGBA8*) (*content)->albedo_maps[0].data)[i] = default_albedo;
   }
-  content.illuminance_maps[0].width      = 4;
-  content.illuminance_maps[0].height     = 4;
-  content.illuminance_maps[0].depth      = 1;
-  content.illuminance_maps[0].pitch      = 4;
-  content.illuminance_maps[0].type       = TexDataUINT8;
-  content.illuminance_maps[0].gpu        = 0;
-  content.illuminance_maps[0].volume_tex = 0;
-  content.illuminance_maps[0].data       = (RGBA8*) malloc(sizeof(RGBA8) * 16);
-  memset(content.illuminance_maps[0].data, 0, sizeof(RGBA8) * 16);
-  content.material_maps[0].width      = 4;
-  content.material_maps[0].height     = 4;
-  content.material_maps[0].depth      = 1;
-  content.material_maps[0].pitch      = 4;
-  content.material_maps[0].type       = TexDataUINT8;
-  content.material_maps[0].gpu        = 0;
-  content.material_maps[0].volume_tex = 0;
-  content.material_maps[0].data       = (RGBA8*) malloc(sizeof(RGBA8) * 16);
+  (*content)->illuminance_maps[0].width      = 4;
+  (*content)->illuminance_maps[0].height     = 4;
+  (*content)->illuminance_maps[0].depth      = 1;
+  (*content)->illuminance_maps[0].pitch      = 4;
+  (*content)->illuminance_maps[0].type       = TexDataUINT8;
+  (*content)->illuminance_maps[0].gpu        = 0;
+  (*content)->illuminance_maps[0].volume_tex = 0;
+  (*content)->illuminance_maps[0].data       = (RGBA8*) malloc(sizeof(RGBA8) * 16);
+  memset((*content)->illuminance_maps[0].data, 0, sizeof(RGBA8) * 16);
+  (*content)->material_maps[0].width      = 4;
+  (*content)->material_maps[0].height     = 4;
+  (*content)->material_maps[0].depth      = 1;
+  (*content)->material_maps[0].pitch      = 4;
+  (*content)->material_maps[0].type       = TexDataUINT8;
+  (*content)->material_maps[0].gpu        = 0;
+  (*content)->material_maps[0].volume_tex = 0;
+  (*content)->material_maps[0].data       = (RGBA8*) malloc(sizeof(RGBA8) * 16);
   for (int i = 0; i < 16; i++) {
-    ((RGBA8*) content.material_maps[0].data)[i] = default_material;
+    ((RGBA8*) (*content)->material_maps[0].data)[i] = default_material;
   }
-  content.normal_maps[0].width      = 4;
-  content.normal_maps[0].height     = 4;
-  content.normal_maps[0].depth      = 1;
-  content.normal_maps[0].pitch      = 4;
-  content.normal_maps[0].type       = TexDataUINT8;
-  content.normal_maps[0].gpu        = 0;
-  content.normal_maps[0].volume_tex = 0;
-  content.normal_maps[0].data       = (RGBA8*) malloc(sizeof(RGBA8) * 16);
+  (*content)->normal_maps[0].width      = 4;
+  (*content)->normal_maps[0].height     = 4;
+  (*content)->normal_maps[0].depth      = 1;
+  (*content)->normal_maps[0].pitch      = 4;
+  (*content)->normal_maps[0].type       = TexDataUINT8;
+  (*content)->normal_maps[0].gpu        = 0;
+  (*content)->normal_maps[0].volume_tex = 0;
+  (*content)->normal_maps[0].data       = (RGBA8*) malloc(sizeof(RGBA8) * 16);
   for (int i = 0; i < 16; i++) {
-    ((RGBA8*) content.normal_maps[0].data)[i] = default_normal;
+    ((RGBA8*) (*content)->normal_maps[0].data)[i] = default_normal;
   }
 
-  content.texture_list           = malloc(sizeof(Wavefront_TextureList));
-  content.texture_list->textures = malloc(sizeof(Wavefront_TextureInstance) * 16);
-  content.texture_list->count    = 0;
-  content.texture_list->length   = 16;
-
-  return content;
+  (*content)->texture_list           = malloc(sizeof(WavefrontTextureList));
+  (*content)->texture_list->textures = malloc(sizeof(WavefrontTextureInstance) * 16);
+  (*content)->texture_list->count    = 0;
+  (*content)->texture_list->length   = 16;
 }
 
-void free_wavefront_content(Wavefront_Content content) {
-  free(content.vertices);
-  free(content.normals);
-  free(content.uvs);
-  free(content.triangles);
-  free(content.materials);
-
-  for (unsigned int i = 0; i < content.albedo_maps_length; i++) {
-    free(content.albedo_maps[i].data);
-  }
-  for (unsigned int i = 0; i < content.illuminance_maps_length; i++) {
-    free(content.illuminance_maps[i].data);
-  }
-  for (unsigned int i = 0; i < content.material_maps_length; i++) {
-    free(content.material_maps[i].data);
-  }
-  for (unsigned int i = 0; i < content.normal_maps_length; i++) {
-    free(content.normal_maps[i].data);
+void wavefront_clear(WavefrontContent** content) {
+  if (!content) {
+    error_message("WavefrontContent is NULL.");
+    return;
   }
 
-  free(content.albedo_maps);
-  free(content.illuminance_maps);
-  free(content.material_maps);
-  free(content.normal_maps);
-  free(content.texture_list->textures);
-  free(content.texture_list);
+  free((*content)->vertices);
+  free((*content)->normals);
+  free((*content)->uvs);
+  free((*content)->triangles);
+  free((*content)->materials);
+
+  for (unsigned int i = 0; i < (*content)->albedo_maps_length; i++) {
+    free((*content)->albedo_maps[i].data);
+  }
+  for (unsigned int i = 0; i < (*content)->illuminance_maps_length; i++) {
+    free((*content)->illuminance_maps[i].data);
+  }
+  for (unsigned int i = 0; i < (*content)->material_maps_length; i++) {
+    free((*content)->material_maps[i].data);
+  }
+  for (unsigned int i = 0; i < (*content)->normal_maps_length; i++) {
+    free((*content)->normal_maps[i].data);
+  }
+
+  free((*content)->albedo_maps);
+  free((*content)->illuminance_maps);
+  free((*content)->material_maps);
+  free((*content)->normal_maps);
+  free((*content)->texture_list->textures);
+  free((*content)->texture_list);
+
+  free(*content);
 }
 
 static size_t hash_djb2(unsigned char* str) {
@@ -141,9 +147,9 @@ static size_t hash_djb2(unsigned char* str) {
 /*
  * @result Index of texture if texture is already present, else 0 (since zero is the NULL texture)
  */
-static uint16_t find_texture(Wavefront_TextureList* textures, uint32_t hash, Wavefront_TextureInstanceType type) {
+static uint16_t find_texture(WavefrontTextureList* textures, uint32_t hash, WavefrontTextureInstanceType type) {
   for (uint32_t i = 0; i < textures->count; i++) {
-    Wavefront_TextureInstance tex = textures->textures[i];
+    WavefrontTextureInstance tex = textures->textures[i];
     if (tex.hash == hash && tex.type == type)
       return tex.offset;
   }
@@ -151,18 +157,18 @@ static uint16_t find_texture(Wavefront_TextureList* textures, uint32_t hash, Wav
   return 0;
 }
 
-static void add_texture(Wavefront_TextureList* textures, uint32_t hash, Wavefront_TextureInstanceType type, uint16_t offset) {
+static void add_texture(WavefrontTextureList* textures, uint32_t hash, WavefrontTextureInstanceType type, uint16_t offset) {
   if (textures->count == textures->length) {
     textures->length *= 2;
-    textures->textures = safe_realloc(textures->textures, sizeof(Wavefront_TextureInstance) * textures->length);
+    textures->textures = safe_realloc(textures->textures, sizeof(WavefrontTextureInstance) * textures->length);
   }
 
-  Wavefront_TextureInstance tex = {.hash = hash, .offset = offset, .type = type};
+  WavefrontTextureInstance tex = {.hash = hash, .offset = offset, .type = type};
 
   textures->textures[textures->count++] = tex;
 }
 
-static void read_materials_file(const char* filename, Wavefront_Content* io_content) {
+static void read_materials_file(WavefrontContent* _content, const char* filename) {
   log_message("Reading *.mtl file (%s)", filename);
   FILE* file = fopen(filename, "r");
 
@@ -171,7 +177,7 @@ static void read_materials_file(const char* filename, Wavefront_Content* io_cont
     return;
   }
 
-  Wavefront_Content content = *io_content;
+  WavefrontContent content = *_content;
 
   unsigned int materials_count        = content.materials_length;
   unsigned int albedo_maps_count      = content.albedo_maps_length;
@@ -186,7 +192,7 @@ static void read_materials_file(const char* filename, Wavefront_Content* io_cont
     fgets(line, LINE_SIZE, file);
 
     if (line[0] == 'n' && line[1] == 'e' && line[2] == 'w' && line[3] == 'm' && line[4] == 't' && line[5] == 'l') {
-      ensure_capacity(content.materials, materials_count, content.materials_length, sizeof(Wavefront_Material));
+      ensure_capacity(content.materials, materials_count, content.materials_length, sizeof(WavefrontMaterial));
       sscanf(line, "%*s %s\n", path);
       size_t hash = hash_djb2((unsigned char*) path);
 
@@ -264,7 +270,7 @@ static void read_materials_file(const char* filename, Wavefront_Content* io_cont
   }
 
   content.materials_length        = materials_count;
-  content.materials               = safe_realloc(content.materials, sizeof(Wavefront_Material) * content.materials_length);
+  content.materials               = safe_realloc(content.materials, sizeof(WavefrontMaterial) * content.materials_length);
   content.albedo_maps_length      = albedo_maps_count;
   content.albedo_maps             = safe_realloc(content.albedo_maps, sizeof(TextureRGBA) * content.albedo_maps_length);
   content.illuminance_maps_length = illuminance_maps_count;
@@ -274,7 +280,7 @@ static void read_materials_file(const char* filename, Wavefront_Content* io_cont
   content.normal_maps_length      = normal_maps_count;
   content.normal_maps             = safe_realloc(content.normal_maps, sizeof(TextureRGBA) * content.normal_maps_length);
 
-  *io_content = content;
+  *_content = content;
 
   fclose(file);
 
@@ -312,7 +318,7 @@ static int read_float_line(const char* str, const int n, float* dst) {
  * @param face2 Pointer to Triangle which gets filled by the data.
  * @result Returns the number of triangles parsed.
  */
-static int read_face(const char* str, Wavefront_Triangle* face1, Wavefront_Triangle* face2) {
+static int read_face(const char* str, WavefrontTriangle* face1, WavefrontTriangle* face2) {
   int ptr = 0;
 
   const unsigned int num_check = 0b00110000;
@@ -362,7 +368,7 @@ static int read_face(const char* str, Wavefront_Triangle* face1, Wavefront_Trian
   switch (data_ptr) {
     case 3:  // Triangle, Only v
     {
-      memset(face1, 0, sizeof(Wavefront_Triangle));
+      memset(face1, 0, sizeof(WavefrontTriangle));
       face1->v1 = data[0];
       face1->v2 = data[1];
       face1->v3 = data[2];
@@ -370,8 +376,8 @@ static int read_face(const char* str, Wavefront_Triangle* face1, Wavefront_Trian
     } break;
     case 4:  // Quad, Only v
     {
-      memset(face1, 0, sizeof(Wavefront_Triangle));
-      memset(face2, 0, sizeof(Wavefront_Triangle));
+      memset(face1, 0, sizeof(WavefrontTriangle));
+      memset(face2, 0, sizeof(WavefrontTriangle));
       face1->v1 = data[0];
       face1->v2 = data[1];
       face1->v3 = data[2];
@@ -382,7 +388,7 @@ static int read_face(const char* str, Wavefront_Triangle* face1, Wavefront_Trian
     } break;
     case 6:  // Triangle, Only v and vt
     {
-      memset(face1, 0, sizeof(Wavefront_Triangle));
+      memset(face1, 0, sizeof(WavefrontTriangle));
       face1->v1  = data[0];
       face1->vt1 = data[1];
       face1->v2  = data[2];
@@ -393,8 +399,8 @@ static int read_face(const char* str, Wavefront_Triangle* face1, Wavefront_Trian
     } break;
     case 8:  // Quad, Only v and vt
     {
-      memset(face1, 0, sizeof(Wavefront_Triangle));
-      memset(face2, 0, sizeof(Wavefront_Triangle));
+      memset(face1, 0, sizeof(WavefrontTriangle));
+      memset(face2, 0, sizeof(WavefrontTriangle));
       face1->v1  = data[0];
       face1->vt1 = data[1];
       face1->v2  = data[2];
@@ -456,7 +462,7 @@ static int read_face(const char* str, Wavefront_Triangle* face1, Wavefront_Trian
   return tris;
 }
 
-int read_wavefront_file(const char* filename, Wavefront_Content* io_content) {
+int wavefront_read_file(WavefrontContent* _content, const char* filename) {
   log_message("Reading *.obj file (%s)", filename);
   bench_tic();
   FILE* file = fopen(filename, "r");
@@ -466,7 +472,7 @@ int read_wavefront_file(const char* filename, Wavefront_Content* io_content) {
     return -1;
   }
 
-  Wavefront_Content content = *io_content;
+  WavefrontContent content = *_content;
 
   const unsigned int vertices_offset = content.vertices_length;
   const unsigned int normals_offset  = content.normals_length;
@@ -500,30 +506,30 @@ int read_wavefront_file(const char* filename, Wavefront_Content* io_content) {
     while ((eol = strchr(line, '\n'))) {
       *eol = '\0';
       if (line[0] == 'v' && line[1] == ' ') {
-        ensure_capacity(content.vertices, vertices_count, content.vertices_length, sizeof(Wavefront_Vertex));
-        Wavefront_Vertex v;
+        ensure_capacity(content.vertices, vertices_count, content.vertices_length, sizeof(WavefrontVertex));
+        WavefrontVertex v;
         read_float_line(line + 2, 3, &v.x);
         content.vertices[vertices_count] = v;
         vertices_count++;
       }
       else if (line[0] == 'v' && line[1] == 'n') {
-        ensure_capacity(content.normals, normals_count, content.normals_length, sizeof(Wavefront_Normal));
-        Wavefront_Normal n;
+        ensure_capacity(content.normals, normals_count, content.normals_length, sizeof(WavefrontNormal));
+        WavefrontNormal n;
         read_float_line(line + 3, 3, &n.x);
         content.normals[normals_count] = n;
         normals_count++;
       }
       else if (line[0] == 'v' && line[1] == 't') {
-        ensure_capacity(content.uvs, uvs_count, content.uvs_length, sizeof(Wavefront_UV));
-        Wavefront_UV uv;
+        ensure_capacity(content.uvs, uvs_count, content.uvs_length, sizeof(WavefrontUV));
+        WavefrontUV uv;
         read_float_line(line + 3, 2, &uv.u);
         content.uvs[uvs_count] = uv;
         uvs_count++;
       }
       else if (line[0] == 'f') {
-        ensure_capacity(content.triangles, triangles_count, content.triangles_length, sizeof(Wavefront_Triangle));
-        Wavefront_Triangle face1;
-        Wavefront_Triangle face2;
+        ensure_capacity(content.triangles, triangles_count, content.triangles_length, sizeof(WavefrontTriangle));
+        WavefrontTriangle face1;
+        WavefrontTriangle face2;
         const int returned_faces = read_face(line, &face1, &face2);
 
         if (returned_faces >= 1) {
@@ -570,7 +576,7 @@ int read_wavefront_file(const char* filename, Wavefront_Content* io_content) {
         if (!already_loaded) {
           ensure_capacity(loaded_mtls, loaded_mtls_count, loaded_mtls_length, sizeof(size_t));
           loaded_mtls[loaded_mtls_count++] = hash;
-          read_materials_file(path, &content);
+          read_materials_file(&content, path);
           materials_count = content.materials_length;
         }
       }
@@ -594,15 +600,15 @@ int read_wavefront_file(const char* filename, Wavefront_Content* io_content) {
   }
 
   content.vertices_length  = vertices_count;
-  content.vertices         = safe_realloc(content.vertices, sizeof(Wavefront_Vertex) * content.vertices_length);
+  content.vertices         = safe_realloc(content.vertices, sizeof(WavefrontVertex) * content.vertices_length);
   content.normals_length   = normals_count;
-  content.normals          = safe_realloc(content.normals, sizeof(Wavefront_Normal) * content.normals_length);
+  content.normals          = safe_realloc(content.normals, sizeof(WavefrontNormal) * content.normals_length);
   content.uvs_length       = uvs_count;
-  content.uvs              = safe_realloc(content.uvs, sizeof(Wavefront_UV) * content.uvs_length);
+  content.uvs              = safe_realloc(content.uvs, sizeof(WavefrontUV) * content.uvs_length);
   content.triangles_length = triangles_count;
-  content.triangles        = safe_realloc(content.triangles, sizeof(Wavefront_Triangle) * content.triangles_length);
+  content.triangles        = safe_realloc(content.triangles, sizeof(WavefrontTriangle) * content.triangles_length);
 
-  *io_content = content;
+  *_content = content;
 
   free(loaded_mtls);
   free(path);
@@ -615,15 +621,15 @@ int read_wavefront_file(const char* filename, Wavefront_Content* io_content) {
   return 0;
 }
 
-TextureAssignment* get_texture_assignments(Wavefront_Content content) {
-  TextureAssignment* texture_assignments = malloc(sizeof(TextureAssignment) * content.materials_length);
+TextureAssignment* wavefront_generate_texture_assignments(WavefrontContent* content) {
+  TextureAssignment* texture_assignments = malloc(sizeof(TextureAssignment) * content->materials_length);
 
-  for (unsigned int i = 0; i < content.materials_length; i++) {
+  for (unsigned int i = 0; i < content->materials_length; i++) {
     TextureAssignment assignment;
-    assignment.albedo_map      = content.materials[i].albedo_texture;
-    assignment.illuminance_map = content.materials[i].illuminance_texture;
-    assignment.material_map    = content.materials[i].material_texture;
-    assignment.normal_map      = content.materials[i].normal_texture;
+    assignment.albedo_map      = content->materials[i].albedo_texture;
+    assignment.illuminance_map = content->materials[i].illuminance_texture;
+    assignment.material_map    = content->materials[i].material_texture;
+    assignment.normal_map      = content->materials[i].normal_texture;
 
     texture_assignments[i] = assignment;
   }
@@ -631,111 +637,111 @@ TextureAssignment* get_texture_assignments(Wavefront_Content content) {
   return texture_assignments;
 }
 
-unsigned int convert_wavefront_content(Triangle** triangles, Wavefront_Content content) {
+unsigned int wavefront_convert_content(WavefrontContent* content, Triangle** triangles) {
   bench_tic();
 
-  unsigned int count = content.triangles_length;
+  unsigned int count = content->triangles_length;
 
   *triangles       = (Triangle*) malloc(sizeof(Triangle) * count);
   unsigned int ptr = 0;
 
   for (unsigned int j = 0; j < count; j++) {
-    Wavefront_Triangle t = content.triangles[j];
+    WavefrontTriangle t = content->triangles[j];
     Triangle triangle;
 
-    Wavefront_Vertex v;
+    WavefrontVertex v;
 
-    t.v1 += (t.v1 < 0) ? content.vertices_length + 1 : 0;
+    t.v1 += (t.v1 < 0) ? content->vertices_length + 1 : 0;
 
-    if (t.v1 > content.vertices_length) {
+    if (t.v1 > content->vertices_length) {
       continue;
     }
     else {
-      v = content.vertices[t.v1 - 1];
+      v = content->vertices[t.v1 - 1];
     }
 
     triangle.vertex.x = v.x;
     triangle.vertex.y = v.y;
     triangle.vertex.z = v.z;
 
-    t.v2 += (t.v2 < 0) ? content.vertices_length + 1 : 0;
+    t.v2 += (t.v2 < 0) ? content->vertices_length + 1 : 0;
 
-    if (t.v2 > content.vertices_length) {
+    if (t.v2 > content->vertices_length) {
       continue;
     }
     else {
-      v = content.vertices[t.v2 - 1];
+      v = content->vertices[t.v2 - 1];
     }
 
     triangle.edge1.x = v.x - triangle.vertex.x;
     triangle.edge1.y = v.y - triangle.vertex.y;
     triangle.edge1.z = v.z - triangle.vertex.z;
 
-    t.v3 += (t.v3 < 0) ? content.vertices_length + 1 : 0;
+    t.v3 += (t.v3 < 0) ? content->vertices_length + 1 : 0;
 
-    if (t.v3 > content.vertices_length) {
+    if (t.v3 > content->vertices_length) {
       continue;
     }
     else {
-      v = content.vertices[t.v3 - 1];
+      v = content->vertices[t.v3 - 1];
     }
 
     triangle.edge2.x = v.x - triangle.vertex.x;
     triangle.edge2.y = v.y - triangle.vertex.y;
     triangle.edge2.z = v.z - triangle.vertex.z;
 
-    Wavefront_UV uv;
+    WavefrontUV uv;
 
-    t.vt1 += (t.vt1 < 0) ? content.uvs_length + 1 : 0;
+    t.vt1 += (t.vt1 < 0) ? content->uvs_length + 1 : 0;
 
-    if (t.vt1 > content.uvs_length || t.vt1 == 0) {
+    if (t.vt1 > content->uvs_length || t.vt1 == 0) {
       uv.u = 0.0f;
       uv.v = 0.0f;
     }
     else {
-      uv = content.uvs[t.vt1 - 1];
+      uv = content->uvs[t.vt1 - 1];
     }
 
     triangle.vertex_texture.u = uv.u;
     triangle.vertex_texture.v = uv.v;
 
-    t.vt2 += (t.vt2 < 0) ? content.uvs_length + 1 : 0;
+    t.vt2 += (t.vt2 < 0) ? content->uvs_length + 1 : 0;
 
-    if (t.vt2 > content.uvs_length || t.vt2 == 0) {
+    if (t.vt2 > content->uvs_length || t.vt2 == 0) {
       uv.u = 0.0f;
       uv.v = 0.0f;
     }
     else {
-      uv = content.uvs[t.vt2 - 1];
+      uv = content->uvs[t.vt2 - 1];
     }
 
     triangle.edge1_texture.u = uv.u - triangle.vertex_texture.u;
     triangle.edge1_texture.v = uv.v - triangle.vertex_texture.v;
 
-    t.vt3 += (t.vt3 < 0) ? content.uvs_length + 1 : 0;
+    t.vt3 += (t.vt3 < 0) ? content->uvs_length + 1 : 0;
 
-    if (t.vt3 > content.uvs_length || t.vt3 == 0) {
+    if (t.vt3 > content->uvs_length || t.vt3 == 0) {
       uv.u = 0.0f;
       uv.v = 0.0f;
     }
     else {
-      uv = content.uvs[t.vt3 - 1];
+      uv = content->uvs[t.vt3 - 1];
     }
 
     triangle.edge2_texture.u = uv.u - triangle.vertex_texture.u;
     triangle.edge2_texture.v = uv.v - triangle.vertex_texture.v;
 
-    Wavefront_Normal n;
+    WavefrontNormal n;
 
-    t.vn1 += (t.vn1 < 0) ? content.normals_length + 1 : 0;
+    t.vn1 += (t.vn1 < 0) ? content->normals_length + 1 : 0;
 
-    if (t.vn1 > content.normals_length || t.vn1 == 0) {
+    if (t.vn1 > content->normals_length || t.vn1 == 0) {
       n.x = 0.0f;
       n.y = 0.0f;
       n.z = 0.0f;
     }
     else {
-      n = content.normals[t.vn1 - 1];
+      n = content->normals[t.vn1 - 1];
 
       const float n_length = 1.0f / sqrtf(n.x * n.x + n.y * n.y + n.z * n.z);
 
@@ -755,15 +761,15 @@ unsigned int convert_wavefront_content(Triangle** triangles, Wavefront_Content c
     triangle.vertex_normal.y = n.y;
     triangle.vertex_normal.z = n.z;
 
-    t.vn2 += (t.vn2 < 0) ? content.normals_length + 1 : 0;
+    t.vn2 += (t.vn2 < 0) ? content->normals_length + 1 : 0;
 
-    if (t.vn2 > content.normals_length || t.vn2 == 0) {
+    if (t.vn2 > content->normals_length || t.vn2 == 0) {
       n.x = 0.0f;
       n.y = 0.0f;
       n.z = 0.0f;
     }
     else {
-      n = content.normals[t.vn2 - 1];
+      n = content->normals[t.vn2 - 1];
 
       const float n_length = 1.0f / sqrtf(n.x * n.x + n.y * n.y + n.z * n.z);
 
@@ -783,15 +789,15 @@ unsigned int convert_wavefront_content(Triangle** triangles, Wavefront_Content c
     triangle.edge1_normal.y = n.y - triangle.vertex_normal.y;
     triangle.edge1_normal.z = n.z - triangle.vertex_normal.z;
 
-    t.vn3 += (t.vn3 < 0) ? content.normals_length + 1 : 0;
+    t.vn3 += (t.vn3 < 0) ? content->normals_length + 1 : 0;
 
-    if (t.vn3 > content.normals_length || t.vn3 == 0) {
+    if (t.vn3 > content->normals_length || t.vn3 == 0) {
       n.x = 0.0f;
       n.y = 0.0f;
       n.z = 0.0f;
     }
     else {
-      n = content.normals[t.vn3 - 1];
+      n = content->normals[t.vn3 - 1];
 
       const float n_length = 1.0f / sqrtf(n.x * n.x + n.y * n.y + n.z * n.z);
 

--- a/src/wavefront.c
+++ b/src/wavefront.c
@@ -115,7 +115,7 @@ void free_wavefront_content(Wavefront_Content content) {
   for (unsigned int i = 0; i < content.material_maps_length; i++) {
     free(content.material_maps[i].data);
   }
-  for (unsigned int i = 0; i < content.material_maps_length; i++) {
+  for (unsigned int i = 0; i < content.normal_maps_length; i++) {
     free(content.normal_maps[i].data);
   }
 


### PR DESCRIPTION
This PR adds normal map support. Details are documented in the LumFileDocs.md file.

Further, improvements were made to the ocean surface which should no longer have issues with intersection or patterns in the normal. Some other refactoring was performed to improve the code. Alpha cutoff is now forced on and ray hit reuse optimization is working again.