### PR TITLE
Raytracing with OptiX

### DIFF
--- a/CMake/FindOptix.cmake
+++ b/CMake/FindOptix.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -26,95 +26,45 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+# Locate the OptiX distribution.  Search relative to the SDK first, then look in the system.
 
-# Adjust the library search path based on the bit-ness of the build.
-# (i.e. 64: bin64, lib64; 32: bin, lib).
-# Note that on Mac, the OptiX library is a universal binary, so we
+# Our initial guess will be within the SDK.
+set(OptiX_INSTALL_DIR "${CMAKE_SOURCE_DIR}/../" CACHE PATH "Path to OptiX installed location.")
+
+# The distribution contains only 64 bit libraries.  Error when we have been mis-configured.
+if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+  if(WIN32)
+    message(SEND_ERROR "Make sure when selecting the generator, you select one with Win64 or x64.")
+  endif()
+  message(FATAL_ERROR "OptiX only supports builds configured for 64 bits.")
+endif()
+
+# search path based on the bit-ness of the build.  (i.e. 64: bin64, lib64; 32:
+# bin, lib).  Note that on Mac, the OptiX library is a universal binary, so we
 # only need to look in lib and not lib64 for 64 bit builds.
-if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND NOT APPLE)
+if(NOT APPLE)
   set(bit_dest "64")
 else()
   set(bit_dest "")
 endif()
-
-#set(OptiX_INSTALL_DIR "" CACHE PATH "Path to OptiX installed location.")
-
-macro(OPTIX_find_api_library name version)
-  find_library(${name}_LIBRARY
-    NAMES ${name}.${version} ${name}
-    PATHS "${OptiX_INSTALL_DIR}/lib${bit_dest}"
-    NO_DEFAULT_PATH
-    )
-  find_library(${name}_LIBRARY
-    NAMES ${name}.${version} ${name}
-    )
-  if(WIN32)
-    find_file(${name}_DLL
-      NAMES ${name}.${version}.dll
-      PATHS "${OptiX_INSTALL_DIR}/bin${bit_dest}"
-      NO_DEFAULT_PATH
-      )
-    find_file(${name}_DLL
-      NAMES ${name}.${version}.dll
-      )
-  endif()
-endmacro()
-
-# OptiX SDKs before 5.1.0 named the library optix.1.lib
-# Linux handles this via symlinks and doesn't need changes to the library name.
-set(OptiX_version "1")
-set(OptiX_Utility_version "1")
-# None of the advanced examples is using OptiX Prime.
-# set(OptiX_Prime_version "1")
-
-# The OptiX library is named with the major and minor digits since OptiX 5.1.0.
-# Dynamically find the matching library name by parsing the OptiX_INSTALL_DIR.
-# This only works if the installation retained the original folder format "OptiX SDK major.minor.micro".
-# We want the concatenated major and minor numbers if the version is greater or equal to 5.1.0.
-# Since OptiX 6.0.0 all DLL names use the fully qualifiied version number major.minor.micro
-if(WIN32)
-  if(OptiX_INSTALL_DIR)
-    string(REPLACE " " ";" OptiX_install_dir_list ${OptiX_INSTALL_DIR})
-    list(LENGTH OptiX_install_dir_list OptiX_install_dir_list_length)
-    if(${OptiX_install_dir_list_length} GREATER 0)
-      # Get the last list element, something like "5.1.0".
-      list(GET OptiX_install_dir_list -1 OptiX_version_string)
-      # Component-wise integer version number comparison (version format is major[.minor[.patch[.tweak]]]).
-      if(${OptiX_version_string} VERSION_GREATER_EQUAL "6.0.0")
-        set(OptiX_version ${OptiX_version_string})
-        set(OptiX_Utility_version ${OptiX_version_string})
-        # set(OptiX_Prime_version ${OptiX_version_string})
-      elseif(${OptiX_version_string} VERSION_GREATER_EQUAL "5.1.0")
-        set(OptiX_version "")
-        string(REPLACE "." ";" OptiX_major_minor_micro_list ${OptiX_version_string})
-        foreach(index RANGE 0 1)
-          list(GET OptiX_major_minor_micro_list ${index} number)
-          string(APPEND OptiX_version ${number})
-        endforeach()
-      endif()
-    endif()
-  endif()
-endif(WIN32)
-
-OPTIX_find_api_library(optix ${OptiX_version})
-OPTIX_find_api_library(optixu ${OptiX_Utility_version})
-# None of the advanced examples is using OptiX Prime.
-# OPTIX_find_api_library(optix_prime ${OptiX_Prime_version})
 
 # Include
 find_path(OptiX_INCLUDE
   NAMES optix.h
   PATHS "${OptiX_INSTALL_DIR}/include"
   NO_DEFAULT_PATH
-)
+  )
 find_path(OptiX_INCLUDE
   NAMES optix.h
-)
+  )
 
 # Check to make sure we found what we were looking for
-function(OptiX_report_error error_message required)
+function(OptiX_report_error error_message required component )
+  if(DEFINED OptiX_FIND_REQUIRED_${component} AND NOT OptiX_FIND_REQUIRED_${component})
+    set(required FALSE)
+  endif()
   if(OptiX_FIND_REQUIRED AND required)
-    message(FATAL_ERROR "${error_message}")
+    message(FATAL_ERROR "${error_message}  Please locate before proceeding.")
   else()
     if(NOT OptiX_FIND_QUIETLY)
       message(STATUS "${error_message}")
@@ -122,84 +72,7 @@ function(OptiX_report_error error_message required)
   endif()
 endfunction()
 
-#if(NOT optix_LIBRARY)
-#  OptiX_report_error("OptiX library not found. Please set OptiX_INSTALL_DIR to locate it automatically." TRUE)
-#endif()
 if(NOT OptiX_INCLUDE)
-  OptiX_report_error("OptiX headers (optix.h and friends) not found. Please set OptiX_INSTALL_DIR to locate them automatically." TRUE)
+  OptiX_report_error("OptiX headers (optix.h and friends) not found." TRUE headers )
 endif()
-# None of the advanced examples is using OptiX Prime.
-# if(NOT optix_prime_LIBRARY)
-#   OptiX_report_error("OptiX Prime library not found. Please set OptiX_INSTALL_DIR to locate it automatically." FALSE)
-# endif()
 
-# Macro for setting up dummy targets
-function(OptiX_add_imported_library name lib_location dll_lib dependent_libs)
-  set(CMAKE_IMPORT_FILE_VERSION 1)
-
-  # Create imported target
-  add_library(${name} SHARED IMPORTED)
-
-  # Import target "optix" for configuration "Debug"
-  if(WIN32)
-    set_target_properties(${name} PROPERTIES
-      IMPORTED_IMPLIB "${lib_location}"
-      #IMPORTED_LINK_INTERFACE_LIBRARIES "glu32;opengl32"
-      IMPORTED_LOCATION "${dll_lib}"
-      IMPORTED_LINK_INTERFACE_LIBRARIES "${dependent_libs}"
-      )
-  elseif(UNIX)
-    set_target_properties(${name} PROPERTIES
-      #IMPORTED_LINK_INTERFACE_LIBRARIES "glu32;opengl32"
-      IMPORTED_LOCATION "${lib_location}"
-      # We don't have versioned filenames for now, and it may not even matter.
-      #IMPORTED_SONAME "${optix_soname}"
-      IMPORTED_LINK_INTERFACE_LIBRARIES "${dependent_libs}"
-      )
-  else()
-    # Unknown system, but at least try and provide the minimum required
-    # information.
-    set_target_properties(${name} PROPERTIES
-      IMPORTED_LOCATION "${lib_location}"
-      IMPORTED_LINK_INTERFACE_LIBRARIES "${dependent_libs}"
-      )
-  endif()
-
-  # Commands beyond this point should not need to know the version.
-  set(CMAKE_IMPORT_FILE_VERSION)
-endfunction()
-
-# Sets up a dummy target
-OptiX_add_imported_library(optix "${optix_LIBRARY}" "${optix_DLL}" "${OPENGL_LIBRARIES}")
-OptiX_add_imported_library(optixu "${optixu_LIBRARY}" "${optixu_DLL}" "")
-# OptiX_add_imported_library(optix_prime "${optix_prime_LIBRARY}" "${optix_prime_DLL}" "")
-
-macro(OptiX_check_same_path libA libB)
-  if(_optix_path_to_${libA})
-    if(NOT _optix_path_to_${libA} STREQUAL _optix_path_to_${libB})
-      # ${libA} and ${libB} are in different paths.  Make sure there isn't a ${libA} next
-      # to the ${libB}.
-      get_filename_component(_optix_name_of_${libA} "${${libA}_LIBRARY}" NAME)
-      if(EXISTS "${_optix_path_to_${libB}}/${_optix_name_of_${libA}}")
-        message(WARNING " ${libA} library found next to ${libB} library that is not being used.  Due to the way we are using rpath, the copy of ${libA} next to ${libB} will be used during loading instead of the one you intended.  Consider putting the libraries in the same directory or moving ${_optix_path_to_${libB}}/${_optix_name_of_${libA} out of the way.")
-      endif()
-    endif()
-    set( _${libA}_rpath "-Wl,-rpath,${_optix_path_to_${libA}}" )
-  endif()
-endmacro()
-# Since liboptix.1.dylib is built with an install name of @rpath, we need to
-# compile our samples with the rpath set to where optix exists.
-if(APPLE)
-  get_filename_component(_optix_path_to_optix "${optix_LIBRARY}" PATH)
-  if(_optix_path_to_optix)
-    set( _optix_rpath "-Wl,-rpath,${_optix_path_to_optix}" )
-  endif()
-  get_filename_component(_optix_path_to_optixu "${optixu_LIBRARY}" PATH)
-  OptiX_check_same_path(optixu optix)
-  # get_filename_component(_optix_path_to_optix_prime "${optix_prime_LIBRARY}" PATH)
-  # OptiX_check_same_path(optix_prime optix)
-  # OptiX_check_same_path(optix_prime optixu)
-  # set( optix_rpath ${_optix_rpath} ${_optixu_rpath} ${_optix_prime_rpath} )
-  set( optix_rpath ${_optix_rpath} ${_optixu_rpath} )
-  list(REMOVE_DUPLICATES optix_rpath)
-endif()

--- a/CMake/PTXUtilities.cmake
+++ b/CMake/PTXUtilities.cmake
@@ -1,0 +1,55 @@
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# ==============================================================================
+# Utility function to get PTX compilation & copying working
+# ==============================================================================
+function(add_ptx_targets project names)
+  # Target to copy PTX files
+  set(LIBRARY_NAMES ${names})
+  list(TRANSFORM LIBRARY_NAMES PREPEND ${project}_)
+  add_custom_target(
+    ${project}_copy_ptx ALL
+    COMMENT "Copy PTX Files for ${project}"
+    DEPENDS ${LIBRARY_NAMES})
+
+  # Target to create PTX directory
+  add_custom_command(TARGET ${project}_copy_ptx PRE_BUILD
+    COMMENT "Create directory for PTX files for ${project}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:${project}>/ptx)
+
+  # Create PTX objects
+  foreach(cur_name ${names})
+    add_library(${project}_${cur_name} OBJECT ${CMAKE_CURRENT_SOURCE_DIR}/src/${cur_name}.cu)
+    set_target_properties(${project}_${cur_name} PROPERTIES CUDA_PTX_COMPILATION ON)
+    add_dependencies(${project} ${project}_${cur_name})
+
+    # Add current PTX to copy target
+    add_custom_command(TARGET ${project}_copy_ptx POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_OBJECTS:${project}_${cur_name}> $<TARGET_FILE_DIR:${project}>/ptx
+      DEPENDS ${project}_${cur_name})
+  endforeach()
+endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,8 @@ endif()
 #=============================================================
 # Find Nvidia packages
 #=============================================================
-find_package(CUDAToolkit 11.6 REQUIRED QUIET)
-find_package(Optix 7.4 REQUIRED QUIET)
+find_package(CUDAToolkit 12.1 REQUIRED QUIET)
+find_package(Optix 7.7 REQUIRED QUIET)
 
 #=============================================================
 # Set files to compile
@@ -141,7 +141,7 @@ endif()
 
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
     if (CMAKE_C_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=native /W4")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=native /W4 -Wno-static-in-inline")
         set(CMAKE_C_FLAGS_RELEASE "/O2")
         set(CMAKE_C_FLAGS_DEBUG "/Od /DEBUG")
     elseif(CMAKE_C_COMPILER_FRONTEND_VARIANT STREQUAL "GNU")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,8 @@ find_package(Optix 7.7 REQUIRED QUIET)
 file(GLOB cpu_source_files "${CMAKE_SOURCE_DIR}/src/*.c" "${CMAKE_SOURCE_DIR}/src/zlib/*.c" "${CMAKE_SOURCE_DIR}/src/UI/*.c")
 file(GLOB gpu_source_files "${CMAKE_SOURCE_DIR}/src/*.cu")
 
+list(REMOVE_ITEM gpu_source_files "${CMAKE_CURRENT_SOURCE_DIR}/src/optix_kernels.cu")
+
 #=============================================================
 # Set include directories
 #=============================================================
@@ -212,6 +214,16 @@ target_link_libraries(Luminary ${SDL2_LIBRARIES} ${SDL2_TTF_LIBRARIES})
 target_link_libraries(Luminary CUDA::cudart)
 target_link_libraries(Luminary CUDA::cuda_driver)
 
+#=============================================================
+# Create PTX files
+#=============================================================
+include(PTXUtilities)
+
+add_ptx_targets(Luminary optix_kernels)
+
+#=============================================================
+# File copying
+#=============================================================
 if(WIN32)
     add_custom_command(TARGET Luminary POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different
         "${SDL2_LIBRARIES_DIR}/SDL2.dll"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Luminary is a renderer using pathtracing. It aims at rendering high quality imag
 
 This project is for fun and to learn more about `real-time rendering`. Current plans can be found in the `Issues` tab.
 
-The goal is to use as few libraries as feasible. Currently, these include `SDL2`, `zlib`, `qoi` and `OptiX`. However, only the denoiser is used from the Optix library.
+The goal is to use as few libraries as feasible. Currently, the following libraries are used: `SDL2`, `zlib`, `qoi` and `OptiX`.
 
 Meshes and textures in the example images are taken from the Ratchet and Clank HD Trilogy and were exported using [Replanetizer](https://github.com/RatchetModding/Replanetizer).
 

--- a/README.md
+++ b/README.md
@@ -96,8 +96,7 @@ In realtime mode, which is used by default, you can control the camera through `
 
 Requirements:
 - CUDA Toolkit 12.1
-- Optix 7.5 SDK
-- Nvidia driver R515 or later
+- Optix 7.7 SDK
 - SDL2 and SDL2_ttf
 - Modern CMake
 - Make or Ninja

--- a/include/buffer.h
+++ b/include/buffer.h
@@ -12,6 +12,7 @@ extern "C" {
   _device_malloc_pitch(buffer, rowstride, num_rows, (char*) #buffer, (char*) __func__, __LINE__)
 #define device_free(buffer, size) _device_free(buffer, size, (char*) #buffer, (char*) __func__, __LINE__)
 #define device_upload(dst, src, size) _device_upload(dst, src, size, (char*) #dst, (char*) #src, (char*) __func__, __LINE__)
+#define device_download(dst, src, size) _device_download(dst, src, size, (char*) #dst, (char*) #src, (char*) __func__, __LINE__)
 #define device_buffer_init(buffer) _device_buffer_init(buffer, (char*) #buffer, (char*) __func__, __LINE__)
 #define device_buffer_free(buffer) _device_buffer_free(buffer, (char*) #buffer, (char*) __func__, __LINE__)
 #define device_buffer_malloc(buffer, element_size, count) \
@@ -35,6 +36,7 @@ void _device_malloc(void** buffer, size_t size, char* buf_name, char* func, int 
 size_t _device_malloc_pitch(void** buffer, size_t rowstride, size_t num_rows, char* buf_name, char* func, int line);
 void _device_free(void* buffer, size_t size, char* buf_name, char* func, int line);
 void _device_upload(void* dst, void* src, size_t size, char* dst_name, char* src_name, char* func, int line);
+void _device_download(void* dst, void* src, size_t size, char* dst_name, char* src_name, char* func, int line);
 void _device_buffer_init(DeviceBuffer** buffer, char* buf_name, char* func, int line);
 void _device_buffer_free(DeviceBuffer* buffer, char* buf_name, char* func, int line);
 void _device_buffer_malloc(DeviceBuffer* buffer, size_t element_size, size_t count, char* buf_name, char* func, int line);

--- a/include/bvh.h
+++ b/include/bvh.h
@@ -47,10 +47,11 @@ struct Node8 {
   uint8_t high_z[8];
 } typedef Node8;
 
-Node2* build_bvh_structure(Triangle** triangles_io, unsigned int* triangles_length_io, unsigned int* nodes_length_out);
+Node2* build_bvh_structure(
+  Triangle** triangles_io, unsigned int* triangles_length_io, unsigned int* nodes_length_out, TriangleGeomData* geom_data);
 Node8* collapse_bvh(
   Node2* binary_nodes, const unsigned int binary_nodes_length, Triangle** triangles_io, const int triangles_length,
-  unsigned int* nodes_length_out);
+  unsigned int* nodes_length_out, TriangleGeomData* geom_data);
 void sort_traversal_elements(Node8** nodes_io, const int nodes_length, Triangle** triangles_io, const int triangles_length);
 
 #endif /* BVH_H */

--- a/include/bvh.h
+++ b/include/bvh.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 
 #include "structs.h"
+#include "utils.h"
 
 struct compressed_vec3 {
   uint8_t x;
@@ -30,28 +31,6 @@ struct Node2 {
   NodeType type;
 } typedef Node2;
 
-struct Node8 {
-  vec3 p;
-  int8_t ex;
-  int8_t ey;
-  int8_t ez;
-  uint8_t imask;
-  int32_t child_node_base_index;
-  int32_t triangle_base_index;
-  uint8_t meta[8];
-  uint8_t low_x[8];
-  uint8_t low_y[8];
-  uint8_t low_z[8];
-  uint8_t high_x[8];
-  uint8_t high_y[8];
-  uint8_t high_z[8];
-} typedef Node8;
-
-Node2* build_bvh_structure(
-  Triangle** triangles_io, unsigned int* triangles_length_io, unsigned int* nodes_length_out, TriangleGeomData* geom_data);
-Node8* collapse_bvh(
-  Node2* binary_nodes, const unsigned int binary_nodes_length, Triangle** triangles_io, const int triangles_length,
-  unsigned int* nodes_length_out, TriangleGeomData* geom_data);
-void sort_traversal_elements(Node8** nodes_io, const int nodes_length, Triangle** triangles_io, const int triangles_length);
+void bvh_init(RaytraceInstance* instance);
 
 #endif /* BVH_H */

--- a/include/device.h
+++ b/include/device.h
@@ -18,6 +18,7 @@ extern "C" {
 #define device_gather_symbol(symbol, data) _device_gather_symbol(&(data), offsetof(DeviceConstantMemory, symbol), sizeof(data))
 void _device_update_symbol(const size_t offset, const void* src, const size_t size);
 void _device_gather_symbol(void* dst, const size_t offset, const size_t size);
+void device_gather_device_table(void* dst, enum cudaMemcpyKind kind);
 void device_initialize_random_generators();
 unsigned int device_get_thread_count();
 void device_init();

--- a/include/optixrt.h
+++ b/include/optixrt.h
@@ -3,6 +3,10 @@
 
 #include "utils.h"
 
+#if __cplusplus
+extern "C" {
+#endif
+
 void optixrt_build_bvh(RaytraceInstance* instance);
 void optixrt_compile_kernels(RaytraceInstance* instance);
 void optixrt_create_groups(RaytraceInstance* instance);
@@ -11,5 +15,9 @@ void optixrt_create_shader_bindings(RaytraceInstance* instance);
 void optixrt_create_params(RaytraceInstance* instance);
 void optixrt_update_params(RaytraceInstance* instance);
 void optixrt_execute(RaytraceInstance* instance);
+
+#if __cplusplus
+}
+#endif
 
 #endif /* OPTIXRT_H */

--- a/include/optixrt.h
+++ b/include/optixrt.h
@@ -1,0 +1,15 @@
+#ifndef OPTIXRT_H
+#define OPTIXRT_H
+
+#include "utils.h"
+
+void optixrt_build_bvh(RaytraceInstance* instance);
+void optixrt_compile_kernels(RaytraceInstance* instance);
+void optixrt_create_groups(RaytraceInstance* instance);
+void optixrt_create_pipeline(RaytraceInstance* instance);
+void optixrt_create_shader_bindings(RaytraceInstance* instance);
+void optixrt_create_params(RaytraceInstance* instance);
+void optixrt_update_params(RaytraceInstance* instance);
+void optixrt_execute(RaytraceInstance* instance);
+
+#endif /* OPTIXRT_H */

--- a/include/optixrt.h
+++ b/include/optixrt.h
@@ -7,12 +7,7 @@
 extern "C" {
 #endif
 
-void optixrt_build_bvh(RaytraceInstance* instance);
-void optixrt_compile_kernels(RaytraceInstance* instance);
-void optixrt_create_groups(RaytraceInstance* instance);
-void optixrt_create_pipeline(RaytraceInstance* instance);
-void optixrt_create_shader_bindings(RaytraceInstance* instance);
-void optixrt_create_params(RaytraceInstance* instance);
+void optixrt_init(RaytraceInstance* instance);
 void optixrt_update_params(RaytraceInstance* instance);
 void optixrt_execute(RaytraceInstance* instance);
 

--- a/include/structs.h
+++ b/include/structs.h
@@ -102,6 +102,17 @@ struct TriangleLight {
   float padding2;
 } typedef TriangleLight;
 
+// Traditional description through vertex buffer and index buffer which is required for OptiX RT.
+// Both vertex buffer and index buffer have a stride of 16 bytes for each triplet
+// but the counts only indicate the number of actual data entries.
+struct TriangleGeomData {
+  float* vertex_buffer;
+  uint32_t* index_buffer;
+  uint32_t vertex_count;
+  uint32_t index_count;
+  uint32_t triangle_count;
+} typedef TriangleGeomData;
+
 /********************************************************
  * Pixelformats
  ********************************************************/

--- a/include/structs.h
+++ b/include/structs.h
@@ -89,7 +89,7 @@ struct TraversalTriangle {
   vec3 edge1;
   vec3 edge2;
   uint32_t albedo_tex;
-  float padding1;
+  uint32_t id;
   float padding2;
 } typedef TraversalTriangle;
 
@@ -112,6 +112,23 @@ struct TriangleGeomData {
   uint32_t index_count;
   uint32_t triangle_count;
 } typedef TriangleGeomData;
+
+struct Node8 {
+  vec3 p;
+  int8_t ex;
+  int8_t ey;
+  int8_t ez;
+  uint8_t imask;
+  int32_t child_node_base_index;
+  int32_t triangle_base_index;
+  uint8_t meta[8];
+  uint8_t low_x[8];
+  uint8_t low_y[8];
+  uint8_t low_z[8];
+  uint8_t high_x[8];
+  uint8_t high_y[8];
+  uint8_t high_z[8];
+} typedef Node8;
 
 /********************************************************
  * Pixelformats

--- a/include/utils.h
+++ b/include/utils.h
@@ -2,6 +2,8 @@
 #define UTILS_H
 
 #include <cuda_runtime_api.h>
+#include <optix.h>
+#include <optix_stubs.h>
 #include <stdlib.h>
 
 #if defined(__GNUC__) || defined(__clang__)
@@ -18,6 +20,15 @@
     if (ans != cudaSuccess) {                                                               \
       crash_message("CUDA Error: %s (%s)", cudaGetErrorName(ans), cudaGetErrorString(ans)); \
     }                                                                                       \
+  }
+
+#define OPTIX_CHECK(call)                                                                                \
+  {                                                                                                      \
+    OptixResult res = call;                                                                              \
+                                                                                                         \
+    if (res != OPTIX_SUCCESS) {                                                                          \
+      crash_message("Optix returned error \"%s\"(%d) in call (%s)", optixGetErrorName(res), res, #call); \
+    }                                                                                                    \
   }
 
 // Flags variables as unused so that no warning is emitted
@@ -368,6 +379,7 @@ struct RaytraceInstance {
   DeviceBuffer* trace_result_buffer;
   DeviceBuffer* state_buffer;
   TextureAtlas tex_atlas;
+  OptixDeviceContext optix_ctx;
 } typedef RaytraceInstance;
 
 struct DevicePointers {

--- a/include/utils.h
+++ b/include/utils.h
@@ -68,7 +68,7 @@ enum ToyShape { TOY_SPHERE = 0, TOY_PLANE = 1 } typedef ToyShape;
 
 enum ToneMap { TONEMAP_NONE = 0, TONEMAP_ACES = 1, TONEMAP_REINHARD = 2, TONEMAP_UNCHARTED2 = 3 } typedef ToneMap;
 
-enum AccelerationStructureType { ACCEL_TYPE_LUMINARY = 0, ACCEL_TYPE_OPTIX = 1 } typedef AccelerationStructureType;
+enum BVHType { BVH_LUMINARY = 0, BVH_OPTIX = 1 } typedef BVHType;
 
 enum Filter {
   FILTER_NONE       = 0,
@@ -387,6 +387,7 @@ struct DeviceConstantMemory {
   RGBF* bloom_scratch;
   RayEmitter emitter;
   int accum_mode;
+  OptixTraversableHandle optix_bvh;
 } typedef DeviceConstantMemory;
 
 struct OptixBVH {
@@ -458,6 +459,7 @@ struct RaytraceInstance {
   TextureAtlas tex_atlas;
   OptixDeviceContext optix_ctx;
   OptixBVH optix_bvh;
+  BVHType bvh_type;
 } typedef RaytraceInstance;
 
 #ifndef min

--- a/include/utils.h
+++ b/include/utils.h
@@ -11,7 +11,6 @@
 #include <intrin.h>
 #endif
 
-#include "bvh.h"
 #include "log.h"
 #include "structs.h"
 
@@ -292,14 +291,10 @@ struct GlobalMaterial {
 struct Scene {
   Camera camera;
   Triangle* triangles;
-  TraversalTriangle* traversal_triangles;
   TriangleLight* triangle_lights;
   TriangleGeomData triangle_data;
-  unsigned int triangles_length;
-  unsigned int triangle_lights_length;
-  Node8* nodes;
-  unsigned int nodes_length;
-  uint16_t materials_length;
+  unsigned int triangle_lights_count;
+  uint16_t materials_count;
   TextureAssignment* texture_assignments;
   Ocean ocean;
   Sky sky;
@@ -388,6 +383,8 @@ struct DeviceConstantMemory {
   RayEmitter emitter;
   int accum_mode;
   OptixTraversableHandle optix_bvh;
+  Node8* bvh_nodes;
+  TraversalTriangle* bvh_triangles;
 } typedef DeviceConstantMemory;
 
 struct OptixBVH {
@@ -458,6 +455,7 @@ struct RaytraceInstance {
   OptixDeviceContext optix_ctx;
   OptixBVH optix_bvh;
   BVHType bvh_type;
+  int luminary_bvh_initialized;
 } typedef RaytraceInstance;
 
 #ifndef min

--- a/include/utils.h
+++ b/include/utils.h
@@ -391,13 +391,11 @@ struct DeviceConstantMemory {
 } typedef DeviceConstantMemory;
 
 struct OptixBVH {
+  int initialized;
   OptixTraversableHandle traversable;
   void* bvh_data;
-  OptixModule module;
-  OptixPipelineCompileOptions pipeline_compile_options;
   OptixPipeline pipeline;
   OptixShaderBindingTable shaders;
-  OptixProgramGroup group[OPTIXRT_NUM_GROUPS];
   DeviceConstantMemory* params;
 } typedef OptixBVH;
 

--- a/include/wavefront.h
+++ b/include/wavefront.h
@@ -89,6 +89,6 @@ void wavefront_init(WavefrontContent** content);
 void wavefront_clear(WavefrontContent** content);
 int wavefront_read_file(WavefrontContent* _content, const char* filename);
 TextureAssignment* wavefront_generate_texture_assignments(WavefrontContent* content);
-unsigned int wavefront_convert_content(WavefrontContent* content, Triangle** triangles);
+unsigned int wavefront_convert_content(WavefrontContent* content, Triangle** triangles, TriangleGeomData* data);
 
 #endif /* WAVEFRONT_H */

--- a/src/UI/UI.c
+++ b/src/UI/UI.c
@@ -55,6 +55,7 @@ static UITab create_general_renderer_panels(UI* ui, RaytraceInstance* instance) 
   panels[i++] = create_dropdown(ui, "Optix Denoiser", &(instance->settings.denoiser), 0, 3, "Off\0On\0Upscaling 4x", 5);
   panels[i++] = create_button(ui, "Reset Renderer", instance, (void (*)(void*)) raytrace_reset, 1);
   panels[i++] = create_info(ui, "Triangle Count", &(instance->scene.triangles_length), PANEL_INFO_TYPE_INT32, PANEL_INFO_STATIC);
+  panels[i++] = create_dropdown(ui, "BVH Type", &(instance->bvh_type), 1, 2, "Luminary\0OptiX", 8);
   panels[i++] = create_dropdown(
     ui, "Shading Mode", &(instance->shading_mode), 1, 7, "Default\0Albedo\0Depth\0Normal\0Trace Heatmap\0Wireframe\0Lights", 8);
   panels[i++] = create_dropdown(ui, "Accumulation Mode", &(instance->accum_mode), 1, 3, "Off\0Accumulation\0Reprojection", 9);

--- a/src/UI/UI.c
+++ b/src/UI/UI.c
@@ -54,13 +54,14 @@ static UITab create_general_renderer_panels(UI* ui, RaytraceInstance* instance) 
   panels[i++] = create_slider(ui, "Reservoir Size", &(instance->settings.reservoir_size), 0, 0.02f, 1.0f, 1024.0f, 0, 1);
   panels[i++] = create_dropdown(ui, "Optix Denoiser", &(instance->settings.denoiser), 0, 3, "Off\0On\0Upscaling 4x", 5);
   panels[i++] = create_button(ui, "Reset Renderer", instance, (void (*)(void*)) raytrace_reset, 1);
-  panels[i++] = create_info(ui, "Triangle Count", &(instance->scene.triangles_length), PANEL_INFO_TYPE_INT32, PANEL_INFO_STATIC);
+  panels[i++] =
+    create_info(ui, "Triangle Count", &(instance->scene.triangle_data.triangle_count), PANEL_INFO_TYPE_INT32, PANEL_INFO_STATIC);
   panels[i++] = create_dropdown(ui, "BVH Type", &(instance->bvh_type), 1, 2, "Luminary\0OptiX", 8);
   panels[i++] = create_dropdown(
     ui, "Shading Mode", &(instance->shading_mode), 1, 7, "Default\0Albedo\0Depth\0Normal\0Trace Heatmap\0Wireframe\0Lights", 8);
   panels[i++] = create_dropdown(ui, "Accumulation Mode", &(instance->accum_mode), 1, 3, "Off\0Accumulation\0Reprojection", 9);
   panels[i++] = create_info(ui, "Temporal Frames", &(instance->temporal_frames), PANEL_INFO_TYPE_INT32, PANEL_INFO_DYNAMIC);
-  panels[i++] = create_info(ui, "Light Source Count", &(instance->scene.triangle_lights_length), PANEL_INFO_TYPE_INT32, PANEL_INFO_STATIC);
+  panels[i++] = create_info(ui, "Light Source Count", &(instance->scene.triangle_lights_count), PANEL_INFO_TYPE_INT32, PANEL_INFO_STATIC);
   panels[i++] = create_slider(ui, "Spatial Resampling Samples", &(instance->spatial_samples), 0, 0.02f, 0.0f, 16.0f, 0, 1);
   panels[i++] = create_slider(ui, "Spatial Resampling Iterations", &(instance->spatial_iterations), 0, 0.02f, 0.0f, 16.0f, 0, 1);
 

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -65,6 +65,11 @@ void _device_upload(void* dst, void* src, size_t size, char* dst_name, char* src
   print_log("[%s:%d] Uploaded %zu bytes from host %s to device %s.", func, line, size, src_name, dst_name);
 }
 
+void _device_download(void* dst, void* src, size_t size, char* dst_name, char* src_name, char* func, int line) {
+  gpuBufferErrchk(cudaMemcpy(dst, src, size, cudaMemcpyDeviceToHost), "none", func, line);
+  print_log("[%s:%d] Downloaded %zu bytes from device %s to host %s.", func, line, size, src_name, dst_name);
+}
+
 void _device_buffer_init(DeviceBuffer** buffer, char* buf_name, char* func, int line) {
   if (*buffer) {
     print_log("[%s:%d] Device buffer %s was already initialized.", func, line, buf_name);

--- a/src/bvh.c
+++ b/src/bvh.c
@@ -8,6 +8,8 @@
 #include <string.h>
 
 #include "bench.h"
+#include "buffer.h"
+#include "device.h"
 #include "structs.h"
 #include "utils.h"
 
@@ -57,6 +59,55 @@ struct Bin {
   int32_t exit;
   uint64_t _p;
 } typedef Bin;
+
+struct BVHWork {
+  Fragment* fragments;
+  uint32_t fragments_count;
+  uint32_t fragments_size;
+  Node2* binary_nodes;
+  uint32_t binary_nodes_count;
+  Node8* nodes;
+  uint32_t nodes_count;
+} typedef BVHWork;
+
+static void _bvh_create_fragments(RaytraceInstance* instance, BVHWork* work) {
+  const uint32_t triangle_count = instance->scene.triangle_data.triangle_count;
+
+  Triangle* triangles = malloc(sizeof(Triangle) * triangle_count);
+  device_download(triangles, instance->scene.triangles, sizeof(Triangle) * triangle_count);
+
+  work->fragments       = malloc(sizeof(Fragment) * triangle_count);
+  work->fragments_size  = triangle_count;
+  work->fragments_count = triangle_count;
+
+  for (uint32_t i = 0; i < triangle_count; i++) {
+    Triangle t  = triangles[i];
+    vec3_p high = {
+      .x = max(t.vertex.x, max(t.vertex.x + t.edge1.x, t.vertex.x + t.edge2.x)),
+      .y = max(t.vertex.y, max(t.vertex.y + t.edge1.y, t.vertex.y + t.edge2.y)),
+      .z = max(t.vertex.z, max(t.vertex.z + t.edge1.z, t.vertex.z + t.edge2.z))};
+    vec3_p low = {
+      .x = min(t.vertex.x, min(t.vertex.x + t.edge1.x, t.vertex.x + t.edge2.x)),
+      .y = min(t.vertex.y, min(t.vertex.y + t.edge1.y, t.vertex.y + t.edge2.y)),
+      .z = min(t.vertex.z, min(t.vertex.z + t.edge1.z, t.vertex.z + t.edge2.z))};
+    vec3_p middle = {.x = (high.x + low.x) * 0.5f, .y = (high.y + low.y) * 0.5f, .z = (high.z + low.z) * 0.5f};
+
+    // Fragments are supposed to be hulls that contain a triangle
+    // They should be as tight as possible but if they are too tight then numerical errors
+    // could result in broken BVHs
+    high.x += fabsf(high.x) * FRAGMENT_ERROR_COMP;
+    high.y += fabsf(high.y) * FRAGMENT_ERROR_COMP;
+    high.z += fabsf(high.z) * FRAGMENT_ERROR_COMP;
+    low.x -= fabsf(low.x) * FRAGMENT_ERROR_COMP;
+    low.y -= fabsf(low.y) * FRAGMENT_ERROR_COMP;
+    low.z -= fabsf(low.z) * FRAGMENT_ERROR_COMP;
+
+    Fragment frag      = {.high = high, .low = low, .middle = middle, .id = i};
+    work->fragments[i] = frag;
+  }
+
+  free(triangles);
+}
 
 static float get_entry_by_axis(const vec3_p p, const Axis axis) {
   switch (axis) {
@@ -131,8 +182,8 @@ static void fit_bounds(const Fragment* fragments, const unsigned int fragments_l
   __m128 low  = _mm_set1_ps(MAX_VALUE);
 
   for (unsigned int i = 0; i < fragments_length; i++) {
-    __m128 high_frag = _mm_load_ps((float*) &(fragments[i].high));
-    __m128 low_frag  = _mm_load_ps((float*) &(fragments[i].low));
+    __m128 high_frag = _mm_loadu_ps((float*) &(fragments[i].high));
+    __m128 low_frag  = _mm_loadu_ps((float*) &(fragments[i].low));
 
     high = _mm_max_ps(high, high_frag);
     low  = _mm_min_ps(low, low_frag);
@@ -317,8 +368,8 @@ static double construct_chopped_bins(
       high_bin = _mm_max_ps(high_bin, high_frag);
       low_bin  = _mm_min_ps(low_bin, low_frag);
 
-      _mm_store_ps((float*) &(bins[j].high), high_bin);
-      _mm_store_ps((float*) &(bins[j].low), low_bin);
+      _mm_storeu_ps((float*) &(bins[j].high), high_bin);
+      _mm_storeu_ps((float*) &(bins[j].low), low_bin);
     }
   }
 
@@ -451,83 +502,46 @@ static void divide_along_axis(
   }
 }
 
-Node2* build_bvh_structure(
-  Triangle** triangles_io, unsigned int* triangles_length_io, unsigned int* nodes_length_out, TriangleGeomData* geom_data) {
-  bench_tic();
-  unsigned int triangles_length = *triangles_length_io;
-  Triangle* triangles           = *triangles_io;
-  unsigned int node_count       = 1 + triangles_length / THRESHOLD_TRIANGLES;
+static void _bvh_build_binary_bvh(BVHWork* work) {
+  Fragment* fragments      = work->fragments;
+  uint32_t fragments_count = work->fragments_count;
 
-  const unsigned int initial_triangles_length = triangles_length;
+  Fragment* fragments_buffer          = (Fragment*) malloc(sizeof(Fragment) * fragments_count * 2);
+  unsigned int fragments_buffer_size  = fragments_count * 2;
+  unsigned int fragments_buffer_count = fragments_count;
 
-  Node2* nodes = (Node2*) malloc(sizeof(Node2) * node_count);
-
-  assert((unsigned long long) nodes, "Failed to allocate BVH nodes!", 1);
-
+  uint32_t node_count = 1 + fragments_count / THRESHOLD_TRIANGLES;
+  Node2* nodes        = malloc(sizeof(Node2) * node_count);
   memset(nodes, 0, sizeof(Node2) * node_count);
-
   nodes[0].triangles_address = 0;
-  nodes[0].triangle_count    = triangles_length;
+  nodes[0].triangle_count    = fragments_count;
   nodes[0].type              = NodeTypeLeaf;
 
-  unsigned int* leaf_nodes     = malloc(sizeof(unsigned int) * node_count);
-  unsigned int leaf_node_count = 0;
-
-  Fragment* fragments           = _mm_malloc(sizeof(Fragment) * triangles_length, 64);
-  unsigned int fragments_length = triangles_length;
-
-  for (unsigned int i = 0; i < triangles_length; i++) {
-    Triangle t  = triangles[i];
-    vec3_p high = {
-      .x = max(t.vertex.x, max(t.vertex.x + t.edge1.x, t.vertex.x + t.edge2.x)),
-      .y = max(t.vertex.y, max(t.vertex.y + t.edge1.y, t.vertex.y + t.edge2.y)),
-      .z = max(t.vertex.z, max(t.vertex.z + t.edge1.z, t.vertex.z + t.edge2.z))};
-    vec3_p low = {
-      .x = min(t.vertex.x, min(t.vertex.x + t.edge1.x, t.vertex.x + t.edge2.x)),
-      .y = min(t.vertex.y, min(t.vertex.y + t.edge1.y, t.vertex.y + t.edge2.y)),
-      .z = min(t.vertex.z, min(t.vertex.z + t.edge1.z, t.vertex.z + t.edge2.z))};
-    vec3_p middle = {.x = (high.x + low.x) * 0.5f, .y = (high.y + low.y) * 0.5f, .z = (high.z + low.z) * 0.5f};
-
-    // Fragments are supposed to be hulls that contain a triangle
-    // They should be as tight as possible but if they are too tight then numerical errors
-    // could result in broken BVHs
-    high.x += fabsf(high.x) * FRAGMENT_ERROR_COMP;
-    high.y += fabsf(high.y) * FRAGMENT_ERROR_COMP;
-    high.z += fabsf(high.z) * FRAGMENT_ERROR_COMP;
-    low.x -= fabsf(low.x) * FRAGMENT_ERROR_COMP;
-    low.y -= fabsf(low.y) * FRAGMENT_ERROR_COMP;
-    low.z -= fabsf(low.z) * FRAGMENT_ERROR_COMP;
-
-    Fragment frag = {.high = high, .low = low, .middle = middle, .id = i};
-    fragments[i]  = frag;
-  }
-
-  Fragment* fragments_buffer           = _mm_malloc(sizeof(Fragment) * fragments_length * 2, 64);
-  unsigned int fragments_buffer_length = fragments_length * 2;
-  unsigned int fragments_buffer_count  = fragments_length;
+  uint32_t* leaf_nodes     = malloc(sizeof(uint32_t) * node_count);
+  uint32_t leaf_node_count = 0;
 
   double root_surface_area;
   vec3_p high_root, low_root;
   {
-    fit_bounds(fragments, fragments_length, &high_root, &low_root);
-    vec3_p diff = {
+    fit_bounds(fragments, fragments_count, &high_root, &low_root);
+    const vec3_p diff = {
       .x = high_root.x - low_root.x, .y = high_root.y - low_root.y, .z = high_root.z - low_root.z, ._p = high_root._p - low_root._p};
 
     root_surface_area = (double) diff.x * (double) diff.y + (double) diff.x * (double) diff.z + (double) diff.y * (double) diff.z;
   }
 
-  Bin* bins = (Bin*) _mm_malloc(sizeof(Bin) * max(OBJECT_SPLIT_BIN_COUNT, SPATIAL_SPLIT_BIN_COUNT), 32);
+  Bin* bins = (Bin*) malloc(sizeof(Bin) * max(OBJECT_SPLIT_BIN_COUNT, SPATIAL_SPLIT_BIN_COUNT));
 
-  unsigned int begin_of_current_nodes = 0;
-  unsigned int end_of_current_nodes   = 1;
-  unsigned int write_ptr              = 1;
+  uint32_t begin_of_current_nodes = 0;
+  uint32_t end_of_current_nodes   = 1;
+  uint32_t write_ptr              = 1;
 
   while (begin_of_current_nodes != end_of_current_nodes) {
-    unsigned int fragments_ptr           = 0;
-    unsigned int buffer_ptr              = 0;
-    unsigned int leaf_nodes_in_iteration = 0;
+    uint32_t fragments_ptr           = 0;
+    uint32_t buffer_ptr              = 0;
+    uint32_t leaf_nodes_in_iteration = 0;
 
-    for (unsigned int node_ptr = begin_of_current_nodes; node_ptr < end_of_current_nodes; node_ptr++) {
+    for (uint32_t node_ptr = begin_of_current_nodes; node_ptr < end_of_current_nodes; node_ptr++) {
       Node2 node         = nodes[node_ptr];
       node.cost_computed = 0;
 
@@ -552,7 +566,7 @@ Node2* build_bvh_structure(
       {
         vec3_p high_parent, low_parent;
         fit_bounds(fragments + fragments_ptr, node.triangle_count, &high_parent, &low_parent);
-        vec3 diff = {.x = high_parent.x - low_parent.x, .y = high_parent.y - low_parent.y, .z = high_parent.z - low_parent.z};
+        const vec3 diff = {.x = high_parent.x - low_parent.x, .y = high_parent.y - low_parent.y, .z = high_parent.z - low_parent.z};
 
         parent_surface_area = (double) diff.x * (double) diff.y + (double) diff.x * (double) diff.z + (double) diff.y * (double) diff.z;
       }
@@ -705,9 +719,9 @@ Node2* build_bvh_structure(
               nodes[leaf_nodes[k]].triangles_address += duplicated_triangles;
           }
 
-          if (fragments_buffer_count >= fragments_buffer_length) {
-            fragments_buffer_length += triangles_length / 2 + 1;
-            fragments_buffer = safe_realloc(fragments_buffer, sizeof(Fragment) * fragments_buffer_length);
+          if (fragments_buffer_count >= fragments_buffer_size) {
+            fragments_buffer_size += fragments_count / 2 + 1;
+            fragments_buffer = safe_realloc(fragments_buffer, sizeof(Fragment) * fragments_buffer_size);
           }
 
           divide_along_axis(
@@ -722,7 +736,7 @@ Node2* build_bvh_structure(
       fragments_ptr += node.triangle_count;
 
       if (write_ptr + 2 >= node_count) {
-        node_count += triangles_length / THRESHOLD_TRIANGLES;
+        node_count += fragments_count / THRESHOLD_TRIANGLES;
         nodes      = safe_realloc(nodes, sizeof(Node2) * node_count);
         leaf_nodes = safe_realloc(leaf_nodes, sizeof(unsigned int) * node_count);
       }
@@ -782,7 +796,8 @@ Node2* build_bvh_structure(
       write_ptr++;
       buffer_ptr += optimal_total_triangles - optimal_split;
 
-      node.triangles_address = -1;
+      node.triangles_address = 0;
+      node.triangle_count    = 0;
       node.type              = NodeTypeInternal;
 
       nodes[node_ptr] = node;
@@ -792,17 +807,17 @@ Node2* build_bvh_structure(
     end_of_current_nodes   = write_ptr;
     leaf_node_count += leaf_nodes_in_iteration;
 
-    if (fragments_ptr != fragments_length) {
-      memcpy(fragments_buffer + buffer_ptr, fragments + fragments_ptr, sizeof(Fragment) * (fragments_length - fragments_ptr));
-      buffer_ptr += fragments_length - fragments_ptr;
-      fragments_ptr += fragments_length - fragments_ptr;
+    if (fragments_ptr != fragments_count) {
+      memcpy(fragments_buffer + buffer_ptr, fragments + fragments_ptr, sizeof(Fragment) * (fragments_count - fragments_ptr));
+      buffer_ptr += fragments_count - fragments_ptr;
+      fragments_ptr += fragments_count - fragments_ptr;
     }
 
-    _mm_free(fragments);
-    fragments               = fragments_buffer;
-    fragments_length        = fragments_buffer_count;
-    fragments_buffer        = _mm_malloc(sizeof(Fragment) * fragments_length * 2, 64);
-    fragments_buffer_length = fragments_length * 2;
+    free(fragments);
+    fragments             = fragments_buffer;
+    fragments_count       = fragments_buffer_count;
+    fragments_buffer      = malloc(sizeof(Fragment) * fragments_count * 2);
+    fragments_buffer_size = fragments_count * 2;
   }
 
   node_count = write_ptr;
@@ -811,65 +826,13 @@ Node2* build_bvh_structure(
 
   nodes = safe_realloc(nodes, sizeof(Node2) * node_count);
 
-  Triangle* triangles_swap = malloc(sizeof(Triangle) * initial_triangles_length);
-  memcpy(triangles_swap, triangles, sizeof(Triangle) * initial_triangles_length);
-  triangles = safe_realloc(triangles, sizeof(Triangle) * fragments_length);
+  free(bins);
 
-  uint32_t* index_buffer_swap = malloc(sizeof(uint32_t) * 4 * geom_data->triangle_count);
-  memcpy(index_buffer_swap, geom_data->index_buffer, sizeof(uint32_t) * 4 * geom_data->triangle_count);
-  geom_data->index_buffer   = safe_realloc(geom_data->index_buffer, sizeof(uint32_t) * 4 * fragments_length);
-  geom_data->triangle_count = fragments_length;
-  geom_data->index_count    = 3 * fragments_length;
-
-  for (unsigned int i = 0; i < fragments_length; i++) {
-    const uint32_t j                   = fragments[i].id;
-    triangles[i]                       = triangles_swap[j];
-    geom_data->index_buffer[4 * i + 0] = index_buffer_swap[4 * j + 0];
-    geom_data->index_buffer[4 * i + 1] = index_buffer_swap[4 * j + 1];
-    geom_data->index_buffer[4 * i + 2] = index_buffer_swap[4 * j + 2];
-    geom_data->index_buffer[4 * i + 3] = index_buffer_swap[4 * j + 3];
-  }
-
-#if BINARY_BVH_ERROR_CHECK
-  for (unsigned int i = 0; i < node_count; i++) {
-    Node2 node = nodes[i];
-
-    if (node.type == NodeTypeNull) {
-      printf("============== Node NULL ===========\n");
-      printf("index: %d (%d)\n", i, node_count);
-    }
-
-    if (node.type != NodeTypeLeaf)
-      continue;
-
-    int dim_errors = 0;
-    dim_errors += (node.self_low.x >= node.self_high.x);
-    dim_errors += (node.self_low.y >= node.self_high.y);
-    dim_errors += (node.self_low.z >= node.self_high.z);
-
-    if (dim_errors) {
-      printf("============== NO VOLUME ===========\n");
-      printf("self_high: %f %f %f\n", node.self_high.x, node.self_high.y, node.self_high.z);
-      printf("self_low: %f %f %f\n", node.self_low.x, node.self_low.y, node.self_low.z);
-      continue;
-    }
-  }
-#endif
-
-  free(triangles_swap);
-  free(index_buffer_swap);
-  _mm_free(fragments);
-  _mm_free(bins);
-
-  *triangles_io = triangles;
-
-  *triangles_length_io = fragments_length;
-
-  *nodes_length_out = node_count;
-
-  bench_toc("Binary BVH Construction");
-
-  return nodes;
+  work->fragments          = fragments;
+  work->fragments_count    = fragments_count;
+  work->fragments_size     = fragments_count;
+  work->binary_nodes       = nodes;
+  work->binary_nodes_count = node_count;
 }
 
 static void compute_single_node_triangles(Node2* binary_nodes, const int index) {
@@ -887,9 +850,7 @@ static void compute_single_node_triangles(Node2* binary_nodes, const int index) 
 
 // recursion seems to be a sufficient solution in this case
 static void compute_node_triangle_properties(Node2* binary_nodes) {
-  bench_tic();
   compute_single_node_triangles(binary_nodes, 0);
-  bench_toc("Node Triangle Property Recovery");
 }
 
 static float cost_distribute(Node2* binary_nodes, Node2 node, int j, int* decision) {
@@ -955,9 +916,7 @@ static void compute_single_node_costs(Node2* binary_nodes, const int index) {
 
 // recursion seems to be a sufficient solution in this case
 static void compute_sah_costs(Node2* binary_nodes) {
-  bench_tic();
   compute_single_node_costs(binary_nodes, 0);
-  bench_toc("SAH Cost Computation");
 }
 
 struct node_packed {
@@ -998,44 +957,41 @@ static void apply_decision(Node2* node, int node_index, int decision, int slot, 
   }
 }
 
-Node8* collapse_bvh(
-  Node2* binary_nodes, const unsigned int binary_nodes_length, Triangle** triangles_io, const int triangles_length,
-  unsigned int* nodes_length_out, TriangleGeomData* geom_data) {
-  compute_node_triangle_properties(binary_nodes);
-  compute_sah_costs(binary_nodes);
+static void _bvh_collapse_bvh(BVHWork* work) {
+  compute_node_triangle_properties(work->binary_nodes);
+  compute_sah_costs(work->binary_nodes);
 
-  bench_tic();
+  const uint32_t fragments_count = work->fragments_count;
 
-  Triangle* triangles = *triangles_io;
-  int node_count      = binary_nodes_length;
+  Node2* binary_nodes               = work->binary_nodes;
+  const uint32_t binary_nodes_count = work->binary_nodes_count;
+
+  uint32_t node_count = binary_nodes_count;
 
   Node8* nodes = (Node8*) malloc(sizeof(Node8) * node_count);
-
-  assert((unsigned long long) nodes, "Failed to allocate BVH nodes!", 1);
-
   memset(nodes, 0, sizeof(Node8) * node_count);
 
-  uint32_t* bvh_triangles = _mm_malloc(sizeof(uint32_t) * triangles_length, 64);
-  uint32_t* new_triangles = _mm_malloc(sizeof(uint32_t) * triangles_length, 64);
+  uint32_t* bvh_fragments = malloc(sizeof(uint32_t) * fragments_count);
+  uint32_t* new_fragments = malloc(sizeof(uint32_t) * fragments_count);
 
-  for (int i = 0; i < triangles_length; i++) {
-    bvh_triangles[i] = i;
-    new_triangles[i] = i;
+  for (uint32_t i = 0; i < fragments_count; i++) {
+    bvh_fragments[i] = i;
+    new_fragments[i] = i;
   }
 
   nodes[0].triangle_base_index   = 0;
   nodes[0].child_node_base_index = 0;
 
-  int begin_of_current_nodes = 0;
-  int end_of_current_nodes   = 1;
-  int write_ptr              = 1;
-  int triangles_ptr          = 0;
+  uint32_t begin_of_current_nodes = 0;
+  uint32_t end_of_current_nodes   = 1;
+  uint32_t write_ptr              = 1;
+  uint32_t triangles_ptr          = 0;
 
   while (begin_of_current_nodes != end_of_current_nodes) {
-    for (int node_ptr = begin_of_current_nodes; node_ptr < end_of_current_nodes; node_ptr++) {
+    for (uint32_t node_ptr = begin_of_current_nodes; node_ptr < end_of_current_nodes; node_ptr++) {
       Node8 node = nodes[node_ptr];
 
-      int binary_index = node.child_node_base_index;
+      const uint32_t binary_index = node.child_node_base_index;
 
       node.child_node_base_index = write_ptr;
       node.triangle_base_index   = triangles_ptr;
@@ -1172,7 +1128,7 @@ Node8* collapse_bvh(
       int triangle_counting_address = 0;
 
       if (write_ptr + 8 >= node_count) {
-        node_count += binary_nodes_length;
+        node_count += binary_nodes_count;
         nodes = safe_realloc(nodes, sizeof(Node8) * node_count);
       }
 
@@ -1202,7 +1158,7 @@ Node8* collapse_bvh(
 
           node.meta[i] = meta;
 
-          memcpy(new_triangles + triangles_ptr, bvh_triangles + base_child.triangles_address, sizeof(uint32_t) * base_child.triangle_count);
+          memcpy(new_fragments + triangles_ptr, bvh_fragments + base_child.triangles_address, sizeof(uint32_t) * base_child.triangle_count);
 
           triangles_ptr += base_child.triangle_count;
           triangle_counting_address += base_child.triangle_count;
@@ -1242,48 +1198,33 @@ Node8* collapse_bvh(
     end_of_current_nodes   = write_ptr;
   }
 
-  _mm_free(bvh_triangles);
-  bvh_triangles = new_triangles;
+  free(bvh_fragments);
+  bvh_fragments = new_fragments;
 
-  Triangle* triangles_swap = malloc(sizeof(Triangle) * triangles_length);
-  memcpy(triangles_swap, triangles, sizeof(Triangle) * triangles_length);
+  Fragment* fragments_swap = malloc(sizeof(Fragment) * fragments_count);
+  memcpy(fragments_swap, work->fragments, sizeof(Fragment) * fragments_count);
 
-  uint32_t* index_buffer_swap = malloc(sizeof(uint32_t) * 4 * geom_data->triangle_count);
-  memcpy(index_buffer_swap, geom_data->index_buffer, sizeof(uint32_t) * 4 * geom_data->triangle_count);
-
-  for (int i = 0; i < triangles_length; i++) {
-    const uint32_t j                   = bvh_triangles[i];
-    triangles[i]                       = triangles_swap[j];
-    geom_data->index_buffer[4 * i + 0] = index_buffer_swap[4 * j + 0];
-    geom_data->index_buffer[4 * i + 1] = index_buffer_swap[4 * j + 1];
-    geom_data->index_buffer[4 * i + 2] = index_buffer_swap[4 * j + 2];
-    geom_data->index_buffer[4 * i + 3] = index_buffer_swap[4 * j + 3];
+  for (uint32_t i = 0; i < fragments_count; i++) {
+    work->fragments[i] = fragments_swap[bvh_fragments[i]];
   }
 
-  free(triangles_swap);
-  free(index_buffer_swap);
-
-  _mm_free(new_triangles);
+  free(fragments_swap);
+  free(new_fragments);
 
   node_count = write_ptr;
 
   nodes = safe_realloc(nodes, sizeof(Node8) * node_count);
 
-  *triangles_io = triangles;
-
-  *nodes_length_out = node_count;
-
-  bench_toc("Collapsing BVH");
-
-  return nodes;
+  work->nodes       = nodes;
+  work->nodes_count = node_count;
 }
 
-static void sort_triangles_depth_first(Triangle* src, Triangle* dst, Node8* nodes, const int node_index, int* offset) {
+static void sort_fragments_depth_first(Fragment* src, Fragment* dst, Node8* nodes, const int node_index, int* offset) {
   Node8* node = nodes + node_index;
 
   const uint8_t imask = node->imask;
 
-  const int new_triangle_base_index = *offset;
+  const int new_fragment_base_index = *offset;
   int new_rel_offset                = 0;
 
   // Insert Leaf Nodes
@@ -1307,7 +1248,7 @@ static void sort_triangles_depth_first(Triangle* src, Triangle* dst, Node8* node
     new_rel_offset += count;
   }
 
-  node->triangle_base_index = new_triangle_base_index;
+  node->triangle_base_index = new_fragment_base_index;
 
   int child_index = node->child_node_base_index;
 
@@ -1317,7 +1258,7 @@ static void sort_triangles_depth_first(Triangle* src, Triangle* dst, Node8* node
       continue;
 
     const int index = child_index++;
-    sort_triangles_depth_first(src, dst, nodes, index, offset);
+    sort_fragments_depth_first(src, dst, nodes, index, offset);
   }
 }
 
@@ -1354,16 +1295,9 @@ static void sort_nodes_depth_first(Node8* src, Node8* dst, const int src_index, 
   }
 }
 
-/*
- * Sorts both nodes and triangles into depth first order.
- */
-void sort_traversal_elements(Node8** nodes_io, const int nodes_length, Triangle** triangles_io, const int triangles_length) {
-  bench_tic();
-
-  Triangle* triangles = *triangles_io;
-  Node8* nodes        = *nodes_io;
-
-  Node8* new_nodes = (Node8*) malloc(sizeof(Node8) * nodes_length);
+static void _bvh_postprocess_sort(BVHWork* work) {
+  Node8* nodes     = work->nodes;
+  Node8* new_nodes = (Node8*) malloc(sizeof(Node8) * work->nodes_count);
 
   new_nodes[0] = nodes[0];
 
@@ -1372,20 +1306,89 @@ void sort_traversal_elements(Node8** nodes_io, const int nodes_length, Triangle*
   sort_nodes_depth_first(nodes, new_nodes, 0, 0, &offset);
 
   free(nodes);
+  work->nodes = new_nodes;
 
-  *nodes_io = new_nodes;
-
-  nodes = new_nodes;
-
-  Triangle* new_triangles = (Triangle*) malloc(sizeof(Triangle) * triangles_length);
+  Fragment* fragments     = work->fragments;
+  Fragment* new_fragments = (Fragment*) malloc(sizeof(Fragment) * work->fragments_count);
 
   offset = 0;
 
-  sort_triangles_depth_first(triangles, new_triangles, nodes, 0, &offset);
+  sort_fragments_depth_first(fragments, new_fragments, work->nodes, 0, &offset);
 
+  free(fragments);
+  work->fragments = new_fragments;
+}
+
+static void _bvh_finalize(RaytraceInstance* instance, BVHWork* work) {
+  const uint32_t triangle_count = instance->scene.triangle_data.triangle_count;
+
+  // TODO: The traversal triangle construction could be performed on the GPU.
+  Triangle* triangles = malloc(sizeof(Triangle) * triangle_count);
+  device_download(triangles, instance->scene.triangles, sizeof(Triangle) * triangle_count);
+
+  TextureAssignment* texture_assignments = malloc(sizeof(TextureAssignment) * instance->scene.materials_count);
+  device_download(texture_assignments, instance->scene.texture_assignments, sizeof(TextureAssignment) * instance->scene.materials_count);
+
+  TraversalTriangle* traversal_triangles = malloc(sizeof(TraversalTriangle) * work->fragments_count);
+
+  for (unsigned int i = 0; i < work->fragments_count; i++) {
+    const Fragment frag = work->fragments[i];
+
+    const Triangle triangle = triangles[frag.id];
+
+    const uint32_t albedo_tex = texture_assignments[triangle.object_maps].albedo_map;
+
+    TraversalTriangle tt = {
+      .vertex     = {.x = triangle.vertex.x, .y = triangle.vertex.y, .z = triangle.vertex.z},
+      .edge1      = {.x = triangle.edge1.x, .y = triangle.edge1.y, .z = triangle.edge1.z},
+      .edge2      = {.x = triangle.edge2.x, .y = triangle.edge2.y, .z = triangle.edge2.z},
+      .albedo_tex = albedo_tex,
+      .id         = frag.id};
+    traversal_triangles[i] = tt;
+  }
   free(triangles);
+  free(texture_assignments);
 
-  *triangles_io = new_triangles;
+  void* bvh_triangles;
+  device_malloc(&bvh_triangles, sizeof(TraversalTriangle) * work->fragments_count);
+  device_upload(bvh_triangles, traversal_triangles, sizeof(TraversalTriangle) * work->fragments_count);
 
-  bench_toc("Sorting Traversal Structures");
+  void* nodes;
+  device_malloc(&nodes, sizeof(Node8) * work->nodes_count);
+  device_upload(nodes, work->nodes, sizeof(Node8) * work->nodes_count);
+
+  device_update_symbol(bvh_triangles, bvh_triangles);
+  device_update_symbol(bvh_nodes, nodes);
+
+  // Must be freed only when corresponding upload is known to be finished.
+  free(traversal_triangles);
+
+  instance->luminary_bvh_initialized = 1;
+  instance->temporal_frames          = 0;
+}
+
+static void _bvh_clear_work(BVHWork* work) {
+  if (work->fragments) {
+    free(work->fragments);
+  }
+
+  if (work->binary_nodes) {
+    free(work->binary_nodes);
+  }
+}
+
+void bvh_init(RaytraceInstance* instance) {
+  bench_tic();
+
+  BVHWork work;
+  memset(&work, 0, sizeof(BVHWork));
+
+  _bvh_create_fragments(instance, &work);
+  _bvh_build_binary_bvh(&work);
+  _bvh_collapse_bvh(&work);
+  _bvh_postprocess_sort(&work);
+  _bvh_finalize(instance, &work);
+  _bvh_clear_work(&work);
+
+  bench_toc("BVH Setup (Luminary)");
 }

--- a/src/cuda/brdf.cuh
+++ b/src/cuda/brdf.cuh
@@ -221,7 +221,7 @@ __device__ LightSample sample_light(const vec3 position, uint32_t& ran_offset) {
   uint32_t light_count  = 0;
   light_count += sun_visible;
   light_count += toy_visible;
-  light_count += (device.scene.material.lights_active) ? device.scene.triangle_lights_length : 0;
+  light_count += (device.scene.material.lights_active) ? device.scene.triangle_lights_count : 0;
 
   LightSample selected;
   selected.id          = LIGHT_ID_NONE;

--- a/src/cuda/bvh.cuh
+++ b/src/cuda/bvh.cuh
@@ -347,7 +347,7 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 9) void process_trace_tasks() {
         if (d < depth) {
           cost += 1.0f;
 
-          const int alpha_result = bvh_triangle_intersection_alpha_test(triangle, triangle_index + triangle_task.x, coords);
+          const int alpha_result = bvh_triangle_intersection_alpha_test(triangle, triangle.id, coords);
 
           if (device.iteration_type == TYPE_LIGHT && alpha_result == 0) {
             depth           = -1.0f;

--- a/src/cuda/geometry.cuh
+++ b/src/cuda/geometry.cuh
@@ -358,7 +358,7 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 9) void process_debug_geometry_t
     }
     else if (device.shading_mode == SHADING_HEAT) {
       const float cost  = device.ptrs.trace_result_buffer[pixel].depth;
-      const float value = 1.0f - 1.0f / (powf(cost, 0.25f));
+      const float value = 0.1f * cost;
       const float red   = __saturatef(2.0f * value);
       const float green = __saturatef(2.0f * (value - 0.5f));
       const float blue  = __saturatef((value > 0.5f) ? 4.0f * (0.25f - fabsf(value - 1.0f)) : 4.0f * (0.25f - fabsf(value - 0.25f)));

--- a/src/cuda/memory.cuh
+++ b/src/cuda/memory.cuh
@@ -273,16 +273,17 @@ __device__ void store_light_sample(LightSample* ptr, const LightSample sample, c
 }
 
 __device__ TraversalTriangle load_traversal_triangle(const int offset) {
-  const float4* ptr = (float4*) (device.scene.traversal_triangles + offset);
+  const float4* ptr = (float4*) (device.bvh_triangles + offset);
   const float4 v1   = __ldg(ptr);
   const float4 v2   = __ldg(ptr + 1);
-  const float2 v3   = __ldg((float2*) (ptr + 2));
+  const float4 v3   = __ldg(ptr + 2);
 
   TraversalTriangle triangle;
   triangle.vertex     = get_vector(v1.x, v1.y, v1.z);
   triangle.edge1      = get_vector(v1.w, v2.x, v2.y);
   triangle.edge2      = get_vector(v2.z, v2.w, v3.x);
   triangle.albedo_tex = __float_as_uint(v3.y);
+  triangle.id         = __float_as_uint(v3.z);
 
   return triangle;
 }

--- a/src/cuda/random.cuh
+++ b/src/cuda/random.cuh
@@ -95,8 +95,10 @@ __device__ float white_noise() {
 // Kernels
 ////////////////////////////////////////////////////////////////////
 
+#ifndef RANDOM_NO_KERNELS
 __global__ void initialize_randoms() {
   device.ptrs.randoms[threadIdx.x + blockIdx.x * blockDim.x] = 1;
 }
+#endif
 
 #endif /* CU_RANDOM_H */

--- a/src/cuda/utils.cuh
+++ b/src/cuda/utils.cuh
@@ -38,12 +38,15 @@
 // Device Variables
 //===========================================================================================
 
+#ifndef UTILS_NO_DEVICE_TABLE
 __constant__ DeviceConstantMemory device;
+#endif
 
 //===========================================================================================
 // Functions
 //===========================================================================================
 
+#ifndef UTILS_NO_DEVICE_FUNCTIONS
 __device__ static uint32_t get_pixel_id(const int x, const int y) {
   return x + device.width * y;
 }
@@ -58,6 +61,10 @@ __device__ static int get_task_address(const int number) {
   return get_task_address_of_thread(threadIdx.x, blockIdx.x, number);
 }
 
+__device__ static int get_task_address2(const unsigned int x, const unsigned int y, const int number) {
+  return get_task_address_of_thread(x, y, number);
+}
+
 __device__ static int is_first_ray() {
   return (device.iteration_type == TYPE_CAMERA);
 }
@@ -67,5 +74,6 @@ __device__ static bool proper_light_sample(const uint32_t target_light, const ui
     device.iteration_type == TYPE_CAMERA || ((device.iteration_type == TYPE_LIGHT) && (target_light == source_light))
     || target_light == LIGHT_ID_ANY || (source_light != LIGHT_ID_SUN && target_light == LIGHT_ID_ANY_NO_SUN));
 }
+#endif
 
 #endif /* CU_UTILS_H */

--- a/src/device.cu
+++ b/src/device.cu
@@ -19,6 +19,7 @@
 #include "cuda/utils.cuh"
 #include "device.h"
 #include "log.h"
+#include "optixrt.h"
 #include "structs.h"
 #include "utils.h"
 
@@ -81,7 +82,12 @@ extern "C" void device_execute_main_kernels(RaytraceInstance* instance, int type
 
   preprocess_trace_tasks<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>();
 
-  process_trace_tasks<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>();
+  if (instance->bvh_type == BVH_LUMINARY) {
+    process_trace_tasks<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>();
+  }
+  else {
+    optixrt_execute(instance);
+  }
 
   if (instance->scene.ocean.active && type != TYPE_LIGHT) {
     ocean_depth_trace_tasks<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>();

--- a/src/device.cu
+++ b/src/device.cu
@@ -141,7 +141,12 @@ extern "C" void device_execute_debug_kernels(RaytraceInstance* instance, int typ
 
   preprocess_trace_tasks<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>();
 
-  process_trace_tasks<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>();
+  if (instance->bvh_type == BVH_LUMINARY) {
+    process_trace_tasks<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>();
+  }
+  else {
+    optixrt_execute(instance);
+  }
 
   if (instance->scene.ocean.active && type != TYPE_LIGHT) {
     ocean_depth_trace_tasks<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>();

--- a/src/device.cu
+++ b/src/device.cu
@@ -164,6 +164,10 @@ extern "C" void _device_gather_symbol(void* dst, const size_t offset, size_t siz
   gpuErrchk(cudaMemcpyFromSymbol(dst, device, size, offset, cudaMemcpyDeviceToHost));
 }
 
+extern "C" void device_gather_device_table(void* dst, enum cudaMemcpyKind kind) {
+  gpuErrchk(cudaMemcpyFromSymbol(dst, device, sizeof(DeviceConstantMemory), 0, kind));
+}
+
 extern "C" void device_initialize_random_generators() {
   initialize_randoms<<<BLOCKS_PER_GRID, THREADS_PER_BLOCK>>>();
 }

--- a/src/light.c
+++ b/src/light.c
@@ -135,11 +135,11 @@ void lights_build_set_from_triangles(Scene* scene, TextureRGBA* textures) {
 
   Scene data = *scene;
 
-  unsigned int lights_length = 16;
-  TriangleLight* lights      = (TriangleLight*) malloc(sizeof(TriangleLight) * lights_length);
-  unsigned int light_count   = 0;
+  uint32_t lights_length = 16;
+  TriangleLight* lights  = (TriangleLight*) malloc(sizeof(TriangleLight) * lights_length);
+  uint32_t light_count   = 0;
 
-  for (unsigned int i = 0; i < data.triangles_length; i++) {
+  for (uint32_t i = 0; i < data.triangle_data.triangle_count; i++) {
     const Triangle triangle = data.triangles[i];
 
     const uint16_t tex_index = data.texture_assignments[triangle.object_maps].illuminance_map;
@@ -157,8 +157,8 @@ void lights_build_set_from_triangles(Scene* scene, TextureRGBA* textures) {
 
   lights = safe_realloc(lights, sizeof(TriangleLight) * light_count);
 
-  data.triangle_lights        = lights;
-  data.triangle_lights_length = light_count;
+  data.triangle_lights       = lights;
+  data.triangle_lights_count = light_count;
 
   *scene = data;
 

--- a/src/optix_kernels.cu
+++ b/src/optix_kernels.cu
@@ -39,13 +39,13 @@ extern "C" __global__ void __raygen__optix() {
     const float3 origin = make_float3(task.origin.x, task.origin.y, task.origin.z);
     const float3 ray    = make_float3(task.ray.x, task.ray.y, task.ray.z);
 
-    const float tmax = result.x - eps * fabsf(result.x);
+    const float tmax = result.x;
 
     unsigned int depth  = __float_as_uint(result.x);
     unsigned int hit_id = __float_as_uint(result.y);
     unsigned int cost   = 0;
 
-    optixTrace(device.optix_bvh, origin, ray, eps, tmax, 0.0f, OptixVisibilityMask(0xFFFF), ray_flags, 0, 0, 0, depth, hit_id, cost);
+    optixTrace(device.optix_bvh, origin, ray, 0.0f, tmax, 0.0f, OptixVisibilityMask(0xFFFF), ray_flags, 0, 0, 0, depth, hit_id, cost);
 
     float2 trace_result;
 

--- a/src/optix_kernels.cu
+++ b/src/optix_kernels.cu
@@ -6,23 +6,8 @@
 extern "C" static __constant__ DeviceConstantMemory device;
 
 #include "math.cuh"
+#include "memory.cuh"
 #include "utils.cuh"
-
-__device__ TraceTask load_trace_task_essentials_optix(const void* ptr) {
-  const float4 data0 = __ldcs((float4*) ptr);
-  const float2 data1 = __ldcs(((float2*) ptr) + 2);
-
-  TraceTask task;
-  task.origin.x = data0.x;
-  task.origin.y = data0.y;
-  task.origin.z = data0.z;
-  task.ray.x    = data0.w;
-
-  task.ray.y = data1.x;
-  task.ray.z = data1.y;
-
-  return task;
-}
 
 // Kernels must be named __[SEMANTIC]__..., for example, __raygen__...
 // This can be found under function name prefix in the programming guide
@@ -36,21 +21,19 @@ extern "C" __global__ void __raygen__optix() {
   unsigned int ray_flags;
 
   switch (device.iteration_type) {
+    default:
+    case TYPE_BOUNCE:
     case TYPE_CAMERA:
-      ray_flags = OPTIX_RAY_FLAG_DISABLE_ANYHIT;
+      ray_flags = OPTIX_RAY_FLAG_NONE;
       break;
     case TYPE_LIGHT:
       ray_flags = OPTIX_RAY_FLAG_DISABLE_CLOSESTHIT;
-      break;
-    default:
-    case TYPE_BOUNCE:
-      ray_flags = OPTIX_RAY_FLAG_DISABLE_ANYHIT;
       break;
   }
 
   for (int i = 0; i < trace_task_count; i++) {
     const int offset     = get_task_address2(idx.x, idx.y, i);
-    const TraceTask task = load_trace_task_essentials_optix(device.trace_tasks + offset);
+    const TraceTask task = load_trace_task_essentials(device.trace_tasks + offset);
     const float2 result  = __ldcs((float2*) (device.ptrs.trace_results + offset));
 
     const float3 origin = make_float3(task.origin.x, task.origin.y, task.origin.z);
@@ -60,19 +43,56 @@ extern "C" __global__ void __raygen__optix() {
 
     unsigned int depth  = __float_as_uint(result.x);
     unsigned int hit_id = __float_as_uint(result.y);
+    unsigned int cost   = 0;
 
-    optixTrace(device.optix_bvh, origin, ray, eps, tmax, 0.0f, OptixVisibilityMask(0xFFFF), ray_flags, 0, 0, 0, depth, hit_id);
+    optixTrace(device.optix_bvh, origin, ray, eps, tmax, 0.0f, OptixVisibilityMask(0xFFFF), ray_flags, 0, 0, 0, depth, hit_id, cost);
 
-    const float2 trace_result = make_float2(__uint_as_float(depth), __uint_as_float(hit_id));
+    float2 trace_result;
+
+    if (device.shading_mode == SHADING_HEAT) {
+      trace_result = make_float2(cost, __uint_as_float(hit_id));
+    }
+    else {
+      trace_result = make_float2(__uint_as_float(depth), __uint_as_float(hit_id));
+    }
+
     __stcs((float2*) (device.ptrs.trace_results + offset), trace_result);
   }
 }
 
-extern "C" __global__ void __anyhit__optix() {
-  optixSetPayload_0(__float_as_uint(0.0f));
-  optixSetPayload_1(REJECT_HIT);
+__device__ bool discard_transparent_hit() {
+  const unsigned int hit_id = optixGetPrimitiveIndex();
 
-  optixTerminateRay();
+  const uint32_t tex = device.scene.traversal_triangles[hit_id].albedo_tex;
+
+  if (tex) {
+    float2 ba = optixGetTriangleBarycentrics();
+
+    const UV uv = load_triangle_tex_coords(hit_id, get_UV(ba.x, ba.y));
+
+    const float4 albedo = tex2D<float4>(device.ptrs.albedo_atlas[tex], uv.u, 1.0f - uv.v);
+
+    if (albedo.w <= device.scene.material.alpha_cutoff) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+extern "C" __global__ void __anyhit__optix() {
+  optixSetPayload_2(optixGetPayload_2() + 5);
+
+  if (discard_transparent_hit()) {
+    optixIgnoreIntersection();
+  }
+
+  if (device.iteration_type == TYPE_LIGHT) {
+    optixSetPayload_0(__float_as_uint(0.0f));
+    optixSetPayload_1(REJECT_HIT);
+
+    optixTerminateRay();
+  }
 }
 
 extern "C" __global__ void __closesthit__optix() {

--- a/src/optix_kernels.cu
+++ b/src/optix_kernels.cu
@@ -63,7 +63,8 @@ extern "C" __global__ void __raygen__optix() {
 __device__ bool discard_transparent_hit() {
   const unsigned int hit_id = optixGetPrimitiveIndex();
 
-  const uint32_t tex = device.scene.traversal_triangles[hit_id].albedo_tex;
+  const uint32_t maps = device.scene.triangles[hit_id].object_maps;
+  const uint32_t tex  = device.scene.texture_assignments[maps].albedo_map;
 
   if (tex) {
     float2 ba = optixGetTriangleBarycentrics();
@@ -81,7 +82,7 @@ __device__ bool discard_transparent_hit() {
 }
 
 extern "C" __global__ void __anyhit__optix() {
-  optixSetPayload_2(optixGetPayload_2() + 5);
+  optixSetPayload_2(optixGetPayload_2() + 1);
 
   if (discard_transparent_hit()) {
     optixIgnoreIntersection();

--- a/src/optix_kernels.cu
+++ b/src/optix_kernels.cu
@@ -1,0 +1,14 @@
+#include "math.cuh"
+#include "utils.cuh"
+#include "utils.h"
+
+extern "C" static __constant__ DeviceConstantMemory optix_params;
+
+extern "C" __global__ void __raygen__example() {
+  const uint3 idx = optixGetLaunchIndex();
+
+  // printf does not work inside optix kernels
+  printf("%d %d %d", idx.x, optix_params.width, optix_params.height);
+
+  optix_params.ptrs.frame_output[idx.x] = get_RGBAhalf(255.0f, 0.0f, 0.0f, 0.0f);
+}

--- a/src/optix_kernels.cu
+++ b/src/optix_kernels.cu
@@ -1,14 +1,84 @@
-#include "math.cuh"
-#include "utils.cuh"
+#define UTILS_NO_DEVICE_TABLE
+#define RANDOM_NO_KERNELS
+
 #include "utils.h"
 
-extern "C" static __constant__ DeviceConstantMemory optix_params;
+extern "C" static __constant__ DeviceConstantMemory device;
 
-extern "C" __global__ void __raygen__example() {
-  const uint3 idx = optixGetLaunchIndex();
+#include "math.cuh"
+#include "utils.cuh"
 
-  // printf does not work inside optix kernels
-  printf("%d %d %d", idx.x, optix_params.width, optix_params.height);
+__device__ TraceTask load_trace_task_essentials_optix(const void* ptr) {
+  const float4 data0 = __ldcs((float4*) ptr);
+  const float2 data1 = __ldcs(((float2*) ptr) + 2);
 
-  optix_params.ptrs.frame_output[idx.x] = get_RGBAhalf(255.0f, 0.0f, 0.0f, 0.0f);
+  TraceTask task;
+  task.origin.x = data0.x;
+  task.origin.y = data0.y;
+  task.origin.z = data0.z;
+  task.ray.x    = data0.w;
+
+  task.ray.y = data1.x;
+  task.ray.z = data1.y;
+
+  return task;
+}
+
+// Kernels must be named __[SEMANTIC]__..., for example, __raygen__...
+// This can be found under function name prefix in the programming guide
+
+extern "C" __global__ void __raygen__optix() {
+  const uint3 idx  = optixGetLaunchIndex();
+  const uint3 dimx = optixGetLaunchDimensions();
+
+  const uint16_t trace_task_count = device.trace_count[idx.x + idx.y * dimx.x];
+
+  unsigned int ray_flags;
+
+  switch (device.iteration_type) {
+    case TYPE_CAMERA:
+      ray_flags = OPTIX_RAY_FLAG_DISABLE_ANYHIT;
+      break;
+    case TYPE_LIGHT:
+      ray_flags = OPTIX_RAY_FLAG_DISABLE_CLOSESTHIT;
+      break;
+    default:
+    case TYPE_BOUNCE:
+      ray_flags = OPTIX_RAY_FLAG_DISABLE_ANYHIT;
+      break;
+  }
+
+  for (int i = 0; i < trace_task_count; i++) {
+    const int offset     = get_task_address2(idx.x, idx.y, i);
+    const TraceTask task = load_trace_task_essentials_optix(device.trace_tasks + offset);
+    const float2 result  = __ldcs((float2*) (device.ptrs.trace_results + offset));
+
+    const float3 origin = make_float3(task.origin.x, task.origin.y, task.origin.z);
+    const float3 ray    = make_float3(task.ray.x, task.ray.y, task.ray.z);
+
+    const float tmax = result.x - eps * fabsf(result.x);
+
+    unsigned int depth  = __float_as_uint(result.x);
+    unsigned int hit_id = __float_as_uint(result.y);
+
+    optixTrace(device.optix_bvh, origin, ray, eps, tmax, 0.0f, OptixVisibilityMask(0xFFFF), ray_flags, 0, 0, 0, depth, hit_id);
+
+    const float2 trace_result = make_float2(__uint_as_float(depth), __uint_as_float(hit_id));
+    __stcs((float2*) (device.ptrs.trace_results + offset), trace_result);
+  }
+}
+
+extern "C" __global__ void __anyhit__optix() {
+  optixSetPayload_0(__float_as_uint(0.0f));
+  optixSetPayload_1(REJECT_HIT);
+
+  optixTerminateRay();
+}
+
+extern "C" __global__ void __closesthit__optix() {
+  optixSetPayload_0(__float_as_uint(optixGetRayTmax()));
+  optixSetPayload_1(optixGetPrimitiveIndex());
+}
+
+extern "C" __global__ void __miss__optix() {
 }

--- a/src/optix_kernels.cu
+++ b/src/optix_kernels.cu
@@ -100,6 +100,3 @@ extern "C" __global__ void __closesthit__optix() {
   optixSetPayload_0(__float_as_uint(optixGetRayTmax()));
   optixSetPayload_1(optixGetPrimitiveIndex());
 }
-
-extern "C" __global__ void __miss__optix() {
-}

--- a/src/optixrt.c
+++ b/src/optixrt.c
@@ -129,12 +129,12 @@ void optixrt_compile_kernels(RaytraceInstance* instance) {
   memset(&module_compile_options, 0, sizeof(OptixModuleCompileOptions));
 
   module_compile_options.maxRegisterCount = OPTIX_COMPILE_DEFAULT_MAX_REGISTER_COUNT;
-  module_compile_options.optLevel         = OPTIX_COMPILE_OPTIMIZATION_DEFAULT;
+  module_compile_options.optLevel         = OPTIX_COMPILE_OPTIMIZATION_LEVEL_3;
   module_compile_options.debugLevel       = OPTIX_COMPILE_DEBUG_LEVEL_NONE;
 
   instance->optix_bvh.pipeline_compile_options.usesMotionBlur                   = 0;
   instance->optix_bvh.pipeline_compile_options.traversableGraphFlags            = OPTIX_TRAVERSABLE_GRAPH_FLAG_ALLOW_SINGLE_GAS;
-  instance->optix_bvh.pipeline_compile_options.numPayloadValues                 = 2;
+  instance->optix_bvh.pipeline_compile_options.numPayloadValues                 = 3;
   instance->optix_bvh.pipeline_compile_options.numAttributeValues               = 2;
   instance->optix_bvh.pipeline_compile_options.exceptionFlags                   = OPTIX_EXCEPTION_FLAG_NONE;
   instance->optix_bvh.pipeline_compile_options.pipelineLaunchParamsVariableName = "device";

--- a/src/optixrt.c
+++ b/src/optixrt.c
@@ -170,9 +170,7 @@ void optixrt_init(RaytraceInstance* instance) {
   group_desc[0].raygen.module            = module;
   group_desc[0].raygen.entryFunctionName = "__raygen__optix";
 
-  group_desc[1].kind                   = OPTIX_PROGRAM_GROUP_KIND_MISS;
-  group_desc[1].miss.module            = module;
-  group_desc[1].miss.entryFunctionName = "__miss__optix";
+  group_desc[1].kind = OPTIX_PROGRAM_GROUP_KIND_MISS;
 
   group_desc[2].kind                         = OPTIX_PROGRAM_GROUP_KIND_HITGROUP;
   group_desc[2].hitgroup.moduleAH            = module;

--- a/src/optixrt.c
+++ b/src/optixrt.c
@@ -1,0 +1,219 @@
+#include "optixrt.h"
+
+#include <optix.h>
+#include <optix_stubs.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "bench.h"
+#include "buffer.h"
+#include "device.h"
+#include "utils.h"
+
+void optixrt_build_bvh(RaytraceInstance* instance) {
+  bench_tic();
+
+  OptixAccelBuildOptions build_options;
+  memset(&build_options, 0, sizeof(OptixAccelBuildOptions));
+  build_options.operation             = OPTIX_BUILD_OPERATION_BUILD;
+  build_options.motionOptions.flags   = OPTIX_MOTION_FLAG_NONE;
+  build_options.motionOptions.numKeys = 1;
+  build_options.buildFlags            = OPTIX_BUILD_FLAG_PREFER_FAST_TRACE | OPTIX_BUILD_FLAG_ALLOW_COMPACTION;
+
+  OptixBuildInput build_inputs;
+  memset(&build_inputs, 0, sizeof(OptixBuildInput));
+  build_inputs.type = OPTIX_BUILD_INPUT_TYPE_TRIANGLES;
+
+  build_inputs.triangleArray.vertexFormat        = OPTIX_VERTEX_FORMAT_FLOAT3;
+  build_inputs.triangleArray.vertexStrideInBytes = 16;
+  build_inputs.triangleArray.numVertices         = instance->scene.triangle_data.vertex_count;
+  build_inputs.triangleArray.vertexBuffers       = (CUdeviceptr*) &(instance->scene.triangle_data.vertex_buffer);
+
+  build_inputs.triangleArray.indexFormat        = OPTIX_INDICES_FORMAT_UNSIGNED_INT3;
+  build_inputs.triangleArray.indexStrideInBytes = 16;
+  build_inputs.triangleArray.numIndexTriplets   = instance->scene.triangle_data.triangle_count;
+  build_inputs.triangleArray.indexBuffer        = (CUdeviceptr) instance->scene.triangle_data.index_buffer;
+
+  unsigned int inputFlags[1] = {OPTIX_GEOMETRY_FLAG_DISABLE_TRIANGLE_FACE_CULLING};
+
+  build_inputs.triangleArray.flags         = inputFlags;
+  build_inputs.triangleArray.numSbtRecords = 1;
+
+  OptixAccelBufferSizes buffer_sizes;
+
+  OPTIX_CHECK(optixAccelComputeMemoryUsage(instance->optix_ctx, &build_options, &build_inputs, 1, &buffer_sizes));
+
+  void* temp_buffer;
+  device_malloc(&temp_buffer, buffer_sizes.tempSizeInBytes);
+
+  void* output_buffer;
+  device_malloc(&output_buffer, buffer_sizes.outputSizeInBytes);
+
+  OptixTraversableHandle traversable;
+
+  OptixAccelEmitDesc accel_emit;
+  memset(&accel_emit, 0, sizeof(OptixAccelEmitDesc));
+
+  device_malloc((void**) &accel_emit.result, sizeof(size_t));
+  accel_emit.type = OPTIX_PROPERTY_TYPE_COMPACTED_SIZE;
+
+  OPTIX_CHECK(optixAccelBuild(
+    instance->optix_ctx, 0, &build_options, &build_inputs, 1, (CUdeviceptr) temp_buffer, buffer_sizes.tempSizeInBytes,
+    (CUdeviceptr) output_buffer, buffer_sizes.outputSizeInBytes, &traversable, &accel_emit, 1));
+
+  size_t compact_size;
+
+  device_download(&compact_size, (void*) accel_emit.result, sizeof(size_t));
+
+  device_free((void*) accel_emit.result, sizeof(size_t));
+  device_free(temp_buffer, buffer_sizes.tempSizeInBytes);
+
+  if (compact_size < buffer_sizes.outputSizeInBytes) {
+    void* output_buffer_compact;
+    device_malloc(&output_buffer_compact, compact_size);
+
+    OPTIX_CHECK(optixAccelCompact(instance->optix_ctx, 0, traversable, (CUdeviceptr) output_buffer_compact, compact_size, &traversable));
+
+    device_free(output_buffer, buffer_sizes.outputSizeInBytes);
+
+    output_buffer                  = output_buffer_compact;
+    buffer_sizes.outputSizeInBytes = compact_size;
+  }
+
+  instance->optix_bvh.bvh_data    = output_buffer;
+  instance->optix_bvh.traversable = traversable;
+
+  bench_toc("BVH Construction (OptiX)");
+}
+
+void optixrt_compile_kernels(RaytraceInstance* instance) {
+  bench_tic();
+
+  FILE* file = fopen("ptx/optix_kernels.ptx", "r");
+
+  if (!file) {
+    crash_message("Failed to load OptiX Kernels. Make sure that the file /ptx/optix_kernels.ptx exists.");
+  }
+
+  fseek(file, 0, SEEK_END);
+  long length = ftell(file);
+  fseek(file, 0, SEEK_SET);
+  char* ptx = malloc(length);
+
+  if (!ptx) {
+    fclose(file);
+    crash_message("Failed to allocate ptx string buffer.");
+  }
+
+  fread(ptx, 1, length, file);
+  fclose(file);
+
+  OptixModuleCompileOptions module_compile_options;
+  memset(&module_compile_options, 0, sizeof(OptixModuleCompileOptions));
+
+  module_compile_options.maxRegisterCount = OPTIX_COMPILE_DEFAULT_MAX_REGISTER_COUNT;
+  module_compile_options.optLevel         = OPTIX_COMPILE_OPTIMIZATION_DEFAULT;
+  module_compile_options.debugLevel       = OPTIX_COMPILE_DEBUG_LEVEL_NONE;
+
+  instance->optix_bvh.pipeline_compile_options.usesMotionBlur                   = 0;
+  instance->optix_bvh.pipeline_compile_options.traversableGraphFlags            = OPTIX_TRAVERSABLE_GRAPH_FLAG_ALLOW_SINGLE_GAS;
+  instance->optix_bvh.pipeline_compile_options.numPayloadValues                 = 0;
+  instance->optix_bvh.pipeline_compile_options.numAttributeValues               = 2;
+  instance->optix_bvh.pipeline_compile_options.exceptionFlags                   = OPTIX_EXCEPTION_FLAG_NONE;
+  instance->optix_bvh.pipeline_compile_options.pipelineLaunchParamsVariableName = "optix_params";
+
+  char log[4096];
+  size_t log_size = sizeof(log);
+
+  OPTIX_CHECK(optixModuleCreate(
+    instance->optix_ctx, &module_compile_options, &instance->optix_bvh.pipeline_compile_options, ptx, length, log, &log_size,
+    &instance->optix_bvh.module));
+
+  free(ptx);
+
+  bench_toc("Kernel Compilation (OptiX)");
+}
+
+void optixrt_create_groups(RaytraceInstance* instance) {
+  bench_tic();
+
+  OptixProgramGroupOptions group_options;
+  memset(&group_options, 0, sizeof(OptixProgramGroupOptions));
+
+  OptixProgramGroupDesc group_desc[OPTIXRT_NUM_GROUPS];
+  memset(group_desc, 0, OPTIXRT_NUM_GROUPS * sizeof(OptixProgramGroupDesc));
+
+  group_desc[0].kind                     = OPTIX_PROGRAM_GROUP_KIND_RAYGEN;
+  group_desc[0].raygen.module            = instance->optix_bvh.module;
+  group_desc[0].raygen.entryFunctionName = "__raygen__example";
+
+  group_desc[1].kind = OPTIX_PROGRAM_GROUP_KIND_MISS;
+  group_desc[2].kind = OPTIX_PROGRAM_GROUP_KIND_HITGROUP;
+
+  char log[4096];
+  size_t log_size = sizeof(log);
+
+  OPTIX_CHECK(optixProgramGroupCreate(
+    instance->optix_ctx, group_desc, OPTIXRT_NUM_GROUPS, &group_options, log, &log_size, instance->optix_bvh.group));
+
+  bench_toc("Groups Creation (OptiX)");
+}
+
+void optixrt_create_pipeline(RaytraceInstance* instance) {
+  bench_tic();
+
+  OptixPipelineLinkOptions pipeline_link_options;
+  pipeline_link_options.maxTraceDepth = 1;
+
+  char log[4096];
+  size_t log_size = sizeof(log);
+
+  OPTIX_CHECK(optixPipelineCreate(
+    instance->optix_ctx, &instance->optix_bvh.pipeline_compile_options, &pipeline_link_options, instance->optix_bvh.group,
+    OPTIXRT_NUM_GROUPS, log, &log_size, &instance->optix_bvh.pipeline));
+
+  bench_toc("Pipeline Creation (OptiX)");
+}
+
+void optixrt_create_shader_bindings(RaytraceInstance* instance) {
+  bench_tic();
+
+  char* records;
+  device_malloc((void**) &records, OPTIXRT_NUM_GROUPS * OPTIX_SBT_RECORD_HEADER_SIZE);
+
+  char host_records[OPTIXRT_NUM_GROUPS * OPTIX_SBT_RECORD_HEADER_SIZE];
+
+  for (int i = 0; i < OPTIXRT_NUM_GROUPS; i++) {
+    OPTIX_CHECK(optixSbtRecordPackHeader(instance->optix_bvh.group[i], host_records + i * OPTIX_SBT_RECORD_HEADER_SIZE));
+  }
+
+  gpuErrchk(cudaMemcpy(records, host_records, OPTIXRT_NUM_GROUPS * OPTIX_SBT_RECORD_HEADER_SIZE, cudaMemcpyHostToDevice));
+
+  instance->optix_bvh.shaders.raygenRecord       = (CUdeviceptr) (records + 0 * OPTIX_SBT_RECORD_HEADER_SIZE);
+  instance->optix_bvh.shaders.missRecordBase     = (CUdeviceptr) (records + 1 * OPTIX_SBT_RECORD_HEADER_SIZE);
+  instance->optix_bvh.shaders.hitgroupRecordBase = (CUdeviceptr) (records + 2 * OPTIX_SBT_RECORD_HEADER_SIZE);
+
+  instance->optix_bvh.shaders.missRecordStrideInBytes = OPTIX_SBT_RECORD_HEADER_SIZE;
+  instance->optix_bvh.shaders.missRecordCount         = 1;
+
+  instance->optix_bvh.shaders.hitgroupRecordStrideInBytes = OPTIX_SBT_RECORD_HEADER_SIZE;
+  instance->optix_bvh.shaders.hitgroupRecordCount         = 1;
+
+  bench_toc("Shader Binding (OptiX)");
+}
+
+void optixrt_create_params(RaytraceInstance* instance) {
+  device_malloc((void**) &instance->optix_bvh.params, sizeof(DeviceConstantMemory));
+}
+
+void optixrt_update_params(RaytraceInstance* instance) {
+  // Since this is device -> device, the cost of this is negligble.
+  device_gather_device_table(instance->optix_bvh.params, cudaMemcpyDeviceToDevice);
+}
+
+void optixrt_execute(RaytraceInstance* instance) {
+  optixrt_update_params(instance);
+  OPTIX_CHECK(optixLaunch(
+    instance->optix_bvh.pipeline, 0, (CUdeviceptr) instance->optix_bvh.params, sizeof(DeviceConstantMemory), &instance->optix_bvh.shaders,
+    10, 1, 1));
+}

--- a/src/raytrace.c
+++ b/src/raytrace.c
@@ -2,6 +2,9 @@
 
 #include <cuda_runtime_api.h>
 #include <math.h>
+#include <optix.h>
+// This header must be included exactly be one translation unit
+#include <optix_function_table_definition.h>
 #include <string.h>
 
 #include "buffer.h"
@@ -273,6 +276,9 @@ void raytrace_init(RaytraceInstance** _instance, General general, TextureAtlas t
       instance->output_height *= 2;
     }
   }
+
+  OPTIX_CHECK(optixInit());
+  OPTIX_CHECK(optixDeviceContextCreate((CUcontext) 0, (OptixDeviceContextOptions*) 0, &instance->optix_ctx));
 
   instance->max_ray_depth   = general.max_ray_depth;
   instance->offline_samples = general.samples;

--- a/src/raytrace.c
+++ b/src/raytrace.c
@@ -239,6 +239,10 @@ void raytrace_execute(RaytraceInstance* instance) {
     sky_hdri_generate_LUT(instance);
   }
 
+  if (instance->bvh_type == BVH_OPTIX && !instance->optix_bvh.initialized) {
+    optixrt_init(instance);
+  }
+
   device_generate_tasks();
 
   if (instance->shading_mode) {
@@ -370,13 +374,6 @@ void raytrace_init(RaytraceInstance** _instance, General general, TextureAtlas t
 
   device_sky_generate_LUTs(instance);
   device_cloud_noise_generate(instance);
-
-  optixrt_build_bvh(instance);
-  optixrt_compile_kernels(instance);
-  optixrt_create_groups(instance);
-  optixrt_create_pipeline(instance);
-  optixrt_create_shader_bindings(instance);
-  optixrt_create_params(instance);
 
   raytrace_update_light_resampling_active(instance);
   raytrace_allocate_buffers(instance);

--- a/src/raytrace.c
+++ b/src/raytrace.c
@@ -239,8 +239,6 @@ void raytrace_execute(RaytraceInstance* instance) {
     sky_hdri_generate_LUT(instance);
   }
 
-  optixrt_execute(instance);
-
   device_generate_tasks();
 
   if (instance->shading_mode) {
@@ -296,6 +294,7 @@ void raytrace_init(RaytraceInstance** _instance, General general, TextureAtlas t
   instance->accum_mode         = TEMPORAL_ACCUMULATION;
   instance->spatial_samples    = 5;
   instance->spatial_iterations = 2;
+  instance->bvh_type           = BVH_OPTIX;
 
   instance->atmo_settings.base_density           = scene->sky.base_density;
   instance->atmo_settings.ground_visibility      = scene->sky.ground_visibility;

--- a/src/scene.c
+++ b/src/scene.c
@@ -211,36 +211,10 @@ static General get_default_settings() {
 }
 
 void scene_create_from_wavefront(Scene* scene, WavefrontContent* content) {
-  scene->triangles_length = wavefront_convert_content(content, &scene->triangles, &scene->triangle_data);
+  wavefront_convert_content(content, &scene->triangles, &scene->triangle_data);
 
-  Node2* initial_nodes = build_bvh_structure(&scene->triangles, &scene->triangles_length, &scene->nodes_length, &scene->triangle_data);
-
-  if (!scene->triangles_length) {
-    crash_message("No triangles are left. Did the scene not contain any faces?");
-  }
-
-  scene->nodes = collapse_bvh(
-    initial_nodes, scene->nodes_length, &scene->triangles, scene->triangles_length, &scene->nodes_length, &scene->triangle_data);
-
-  free(initial_nodes);
-
-  // sort_traversal_elements(&scene->nodes, scene->nodes_length, &scene->triangles, scene->triangles_length);
-
-  scene->materials_length    = content->materials_length;
+  scene->materials_count     = content->materials_length;
   scene->texture_assignments = wavefront_generate_texture_assignments(content);
-
-  scene->traversal_triangles = malloc(sizeof(TraversalTriangle) * scene->triangles_length);
-
-  for (unsigned int i = 0; i < scene->triangles_length; i++) {
-    const Triangle triangle   = scene->triangles[i];
-    const uint32_t albedo_tex = scene->texture_assignments[triangle.object_maps].albedo_map;
-    TraversalTriangle tt      = {
-           .vertex     = {.x = triangle.vertex.x, .y = triangle.vertex.y, .z = triangle.vertex.z},
-           .edge1      = {.x = triangle.edge1.x, .y = triangle.edge1.y, .z = triangle.edge1.z},
-           .edge2      = {.x = triangle.edge2.x, .y = triangle.edge2.y, .z = triangle.edge2.z},
-           .albedo_tex = albedo_tex};
-    scene->traversal_triangles[i] = tt;
-  }
 }
 
 RaytraceInstance* scene_load_lum(const char* filename) {
@@ -384,8 +358,6 @@ void scene_clear(Scene** scene) {
   }
 
   free((*scene)->triangles);
-  free((*scene)->traversal_triangles);
-  free((*scene)->nodes);
   free((*scene)->triangle_lights);
   free((*scene)->texture_assignments);
 

--- a/src/scene.c
+++ b/src/scene.c
@@ -211,7 +211,7 @@ static General get_default_settings() {
 }
 
 void scene_create_from_wavefront(Scene* scene, WavefrontContent* content) {
-  scene->triangles_length = wavefront_convert_content(content, &scene->triangles);
+  scene->triangles_length = wavefront_convert_content(content, &scene->triangles, &scene->triangle_data);
 
   Node2* initial_nodes = build_bvh_structure(&scene->triangles, &scene->triangles_length, &scene->nodes_length);
 

--- a/src/scene.c
+++ b/src/scene.c
@@ -213,17 +213,17 @@ static General get_default_settings() {
 void scene_create_from_wavefront(Scene* scene, WavefrontContent* content) {
   scene->triangles_length = wavefront_convert_content(content, &scene->triangles, &scene->triangle_data);
 
-  Node2* initial_nodes = build_bvh_structure(&scene->triangles, &scene->triangles_length, &scene->nodes_length);
+  // Node2* initial_nodes = build_bvh_structure(&scene->triangles, &scene->triangles_length, &scene->nodes_length);
 
   if (!scene->triangles_length) {
     crash_message("No triangles are left. Did the scene not contain any faces?");
   }
 
-  scene->nodes = collapse_bvh(initial_nodes, scene->nodes_length, &scene->triangles, scene->triangles_length, &scene->nodes_length);
+  // scene->nodes = collapse_bvh(initial_nodes, scene->nodes_length, &scene->triangles, scene->triangles_length, &scene->nodes_length);
 
-  free(initial_nodes);
+  // free(initial_nodes);
 
-  sort_traversal_elements(&scene->nodes, scene->nodes_length, &scene->triangles, scene->triangles_length);
+  // sort_traversal_elements(&scene->nodes, scene->nodes_length, &scene->triangles, scene->triangles_length);
 
   scene->materials_length    = content->materials_length;
   scene->texture_assignments = wavefront_generate_texture_assignments(content);

--- a/src/scene.c
+++ b/src/scene.c
@@ -213,15 +213,16 @@ static General get_default_settings() {
 void scene_create_from_wavefront(Scene* scene, WavefrontContent* content) {
   scene->triangles_length = wavefront_convert_content(content, &scene->triangles, &scene->triangle_data);
 
-  // Node2* initial_nodes = build_bvh_structure(&scene->triangles, &scene->triangles_length, &scene->nodes_length);
+  Node2* initial_nodes = build_bvh_structure(&scene->triangles, &scene->triangles_length, &scene->nodes_length, &scene->triangle_data);
 
   if (!scene->triangles_length) {
     crash_message("No triangles are left. Did the scene not contain any faces?");
   }
 
-  // scene->nodes = collapse_bvh(initial_nodes, scene->nodes_length, &scene->triangles, scene->triangles_length, &scene->nodes_length);
+  scene->nodes = collapse_bvh(
+    initial_nodes, scene->nodes_length, &scene->triangles, scene->triangles_length, &scene->nodes_length, &scene->triangle_data);
 
-  // free(initial_nodes);
+  free(initial_nodes);
 
   // sort_traversal_elements(&scene->nodes, scene->nodes_length, &scene->triangles, scene->triangles_length);
 

--- a/src/wavefront.c
+++ b/src/wavefront.c
@@ -665,9 +665,9 @@ unsigned int wavefront_convert_content(WavefrontContent* content, Triangle** tri
       continue;
     }
 
-    data->index_buffer[index_triplet_count * 4 + 0] = t.v1;
-    data->index_buffer[index_triplet_count * 4 + 1] = t.v2;
-    data->index_buffer[index_triplet_count * 4 + 2] = t.v3;
+    data->index_buffer[index_triplet_count * 4 + 0] = t.v1 - 1;
+    data->index_buffer[index_triplet_count * 4 + 1] = t.v2 - 1;
+    data->index_buffer[index_triplet_count * 4 + 2] = t.v3 - 1;
 
     WavefrontUV uv;
 


### PR DESCRIPTION
This PR adds support for ray tracing using OptiX. For this I updated the dependencies (and thus minimum requirements). The OptiX implementation is a good bunch faster than my own implementation but only by about 50% which I would say is pretty good for my implementation considering that it runs entirely on CUDA cores. The new OptiX implementation is the default one now and the Luminary BVH is only built if it is selected in realtime. The option to select the BVH using lum files is not implemented yet. In general, there are a few things in code that have become less than optimal due to this change that I will address in the future whenever I feel like it. These things are not of high priority though so they are no blockers for this PR.

A major issue currently is that the user will now need OptiX installed (or so I would thing) and the OptiX shader ptx file needs to be copied aswell. To avoid the latter I am already working on a solution with which I can embed binary files into executable but more on that when it is done.

Baked files will need some attention again since they are and were broken.

Closes #41