### PR TITLE
Displacement Micromaps

### DIFF
--- a/LumFileDocs.md
+++ b/LumFileDocs.md
@@ -382,7 +382,7 @@ Textures must be in the Portable Network Graphics (`*.png`) file format. They ne
    - Red: Tangent X
    - Green: Tangent Y
    - Blue: Tangent Z
-   - Alpha: Unused
+   - Alpha: Displacement
 
 >📝 Textures must contain gamma information if they are not encoded linearly. Note that GIMP does not correctly export the correct gamma value. Hence, it is important to uncheck "Save gamma" during png export ([See Thread](https://gitlab.gnome.org/GNOME/gimp/-/issues/5363)). If textures are not displayed correctly, make sure that the gamma value used in the png file correctly approximates the color profile otherwise defined in the file.
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ where `File` is a relative or absolute path to a `*.obj`, `*.lum` or `*.baked` f
 -v, --version
         print build information and exit
 
+    --force-displacement
+        turn on displacement map usage on Ampere and Turing architecture GPUs
+
     --qoi
         set output image format to QOI
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Requirements:
 - SSE 4.1 compatible CPU
 - Supported Nvidia GPU (Turing or later)
 
+>📝 The use of opacity micromaps and displacement micromaps at the same time is only possible on Ada Lovelace Arch GPUs. (This seems to not be documented anywhere.)
+
 `zlib` comes as a submodule and is compiled with Luminary, it is not required to have `zlib` installed. This is due to the compiler limitations of CUDA on Windows which makes usage of zlib-ng inconvenient.
 >📝 `zlib` and `qoi` come as git submodules. Make sure to clone the submodules by using `git submodule update --init` after cloning Luminary.
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Requirements:
 - Modern CMake
 - Make or Ninja
 - SSE 4.1 compatible CPU
-- Supported Nvidia GPU (Turing or later)
+- Supported Nvidia GPU (Pascal or later)
 
 >📝 The use of opacity micromaps and displacement micromaps at the same time is only possible on Ada Lovelace Arch GPUs. (This seems to not be documented anywhere.)
 

--- a/include/device.h
+++ b/include/device.h
@@ -53,6 +53,7 @@ void device_cloud_noise_generate(RaytraceInstance* instance);
 ////////////////////////////////////////////////////////////////////
 OptixBuildInputOpacityMicromap micromap_opacity_build(RaytraceInstance* instance);
 void micromap_opacity_free(OptixBuildInputOpacityMicromap data);
+OptixBuildInputDisplacementMicromap micromap_displacement_build(RaytraceInstance* instance);
 
 ////////////////////////////////////////////////////////////////////
 // mipmap.cuh

--- a/include/utils.h
+++ b/include/utils.h
@@ -87,6 +87,17 @@ enum MaterialFresnel { SCHLICK = 0, FDEZ_AGUERA = 1 } typedef MaterialFresnel;
 
 enum DenoisingMode { DENOISING_OFF = 0, DENOISING_ON = 1, DENOISING_UPSCALING = 2 } typedef DenoisingMode;
 
+// Set of architectures supported by Luminary
+enum DeviceArch {
+  DEVICE_ARCH_UNKNOWN = 0,
+  DEVICE_ARCH_PASCAL  = 1,
+  DEVICE_ARCH_VOLTA   = 11,
+  DEVICE_ARCH_TURING  = 2,
+  DEVICE_ARCH_AMPERE  = 3,
+  DEVICE_ARCH_ADA     = 4,
+  DEVICE_ARCH_HOPPER  = 41
+} typedef DeviceArch;
+
 struct DeviceBuffer {
   void* device_pointer;
   size_t size;
@@ -398,6 +409,12 @@ struct OptixBVH {
   DeviceConstantMemory* params;
 } typedef OptixBVH;
 
+struct DeviceInfo {
+  size_t global_mem_size;
+  DeviceArch arch;
+  int rt_core_version;
+} typedef DeviceInfo;
+
 struct RaytraceInstance {
   unsigned int width;
   unsigned int height;
@@ -460,6 +477,7 @@ struct RaytraceInstance {
   OptixBVH optix_bvh;
   BVHType bvh_type;
   int luminary_bvh_initialized;
+  DeviceInfo device_info;
 } typedef RaytraceInstance;
 
 #ifndef min

--- a/include/utils.h
+++ b/include/utils.h
@@ -407,6 +407,7 @@ struct OptixBVH {
   OptixPipeline pipeline;
   OptixShaderBindingTable shaders;
   DeviceConstantMemory* params;
+  int force_dmm_usage;
 } typedef OptixBVH;
 
 struct DeviceInfo {

--- a/src/Luminary.c
+++ b/src/Luminary.c
@@ -108,6 +108,7 @@ int main(int argc, char* argv[]) {
   int post_process_menu        = 0;
   int unittest                 = 0;
   int version_output           = 0;
+  int force_displacement       = 0;
 
   for (int i = 1; i < argc; i++) {
     if (custom_samples) {
@@ -131,6 +132,7 @@ int main(int argc, char* argv[]) {
     post_process_menu |= parse_command(argv[i], "-p", "--post-menu");
     unittest |= parse_command(argv[i], "-u", "--unittest");
     version_output |= parse_command(argv[i], "-v", "--version");
+    force_displacement |= parse_command(argv[i], (char*) 0, "--force-displacement");
 
     if (parse_command(argv[i], (char*) 0, "--png")) {
       img_format = IMGFORMAT_PNG;
@@ -179,6 +181,11 @@ int main(int argc, char* argv[]) {
       error_message("UNITTEST - BRDF failed.");
 
     return 0;
+  }
+
+  if (force_displacement) {
+    log_message("DMM Usage was forced on by the user.");
+    instance->optix_bvh.force_dmm_usage = 1;
   }
 
   instance->realtime = !offline;

--- a/src/cuda/geometry.cuh
+++ b/src/cuda/geometry.cuh
@@ -65,37 +65,7 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 7) void process_geometry_tasks()
 
     vec3 normal = lerp_normals(vertex_normal, edge1_normal, edge2_normal, coords, face_normal);
 
-    if (dot_product(face_normal, normal) < 0.0f) {
-      normal        = scale_vector(normal, -1.0f);
-      vertex_normal = scale_vector(vertex_normal, -1.0f);
-      edge1_normal  = scale_vector(edge1_normal, -1.0f);
-      edge2_normal  = scale_vector(edge2_normal, -1.0f);
-    }
-
-    if (dot_product(face_normal, ray) > 0.0f) {
-      face_normal   = scale_vector(face_normal, -1.0f);
-      normal        = scale_vector(normal, -1.0f);
-      vertex_normal = scale_vector(vertex_normal, -1.0f);
-      edge1_normal  = scale_vector(edge1_normal, -1.0f);
-      edge2_normal  = scale_vector(edge2_normal, -1.0f);
-    }
-
-    /*
-     * I came up with this quickly, problem is that we need to rotate the normal
-     * towards the face normal with our ray is "behind" the shading normal
-     */
-    if (dot_product(normal, ray) > 0.0f) {
-      const float a = sqrtf(1.0f - dot_product(face_normal, ray));
-      const float b = dot_product(face_normal, normal);
-      const float t = a / (a + b + eps);
-      normal        = normalize_vector(add_vector(scale_vector(face_normal, t), scale_vector(normal, 1.0f - t)));
-      vertex_normal = normalize_vector(add_vector(scale_vector(face_normal, t), scale_vector(vertex_normal, 1.0f - t)));
-      edge1_normal  = normalize_vector(add_vector(scale_vector(face_normal, t), scale_vector(edge1_normal, 1.0f - t)));
-      edge2_normal  = normalize_vector(add_vector(scale_vector(face_normal, t), scale_vector(edge2_normal, 1.0f - t)));
-    }
-
-    vec3 terminator = terminator_fix(task.position, vertex, edge1, edge2, vertex_normal, edge1_normal, edge2_normal, coords);
-
+    vec3 terminator;
     if (maps.w != TEXTURE_NONE) {
       const float4 normal_f = geometry_texture_load(device.ptrs.normal_atlas[maps.w], tex_coords);
 
@@ -106,7 +76,47 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 7) void process_geometry_tasks()
 
       Mat3x3 tangent_space = cotangent_frame(normal, edge1, edge2, edge1_texture, edge2_texture);
 
-      normal = normalize_vector(transform_vec3(tangent_space, map_normal));
+      normal     = normalize_vector(transform_vec3(tangent_space, map_normal));
+      terminator = task.position;
+
+      if (dot_product(normal, ray) > 0.0f) {
+        normal        = scale_vector(normal, -1.0f);
+        vertex_normal = scale_vector(vertex_normal, -1.0f);
+        edge1_normal  = scale_vector(edge1_normal, -1.0f);
+        edge2_normal  = scale_vector(edge2_normal, -1.0f);
+      }
+    }
+    else {
+      if (dot_product(face_normal, normal) < 0.0f) {
+        normal        = scale_vector(normal, -1.0f);
+        vertex_normal = scale_vector(vertex_normal, -1.0f);
+        edge1_normal  = scale_vector(edge1_normal, -1.0f);
+        edge2_normal  = scale_vector(edge2_normal, -1.0f);
+      }
+
+      if (dot_product(face_normal, ray) > 0.0f) {
+        face_normal   = scale_vector(face_normal, -1.0f);
+        normal        = scale_vector(normal, -1.0f);
+        vertex_normal = scale_vector(vertex_normal, -1.0f);
+        edge1_normal  = scale_vector(edge1_normal, -1.0f);
+        edge2_normal  = scale_vector(edge2_normal, -1.0f);
+      }
+
+      /*
+       * I came up with this quickly, problem is that we need to rotate the normal
+       * towards the face normal with our ray is "behind" the shading normal
+       */
+      if (dot_product(normal, ray) > 0.0f) {
+        const float a = sqrtf(1.0f - dot_product(face_normal, ray));
+        const float b = dot_product(face_normal, normal);
+        const float t = a / (a + b + eps);
+        normal        = normalize_vector(add_vector(scale_vector(face_normal, t), scale_vector(normal, 1.0f - t)));
+        vertex_normal = normalize_vector(add_vector(scale_vector(face_normal, t), scale_vector(vertex_normal, 1.0f - t)));
+        edge1_normal  = normalize_vector(add_vector(scale_vector(face_normal, t), scale_vector(edge1_normal, 1.0f - t)));
+        edge2_normal  = normalize_vector(add_vector(scale_vector(face_normal, t), scale_vector(edge2_normal, 1.0f - t)));
+      }
+
+      terminator = terminator_fix(task.position, vertex, edge1, edge2, vertex_normal, edge1_normal, edge2_normal, coords);
     }
 
     float roughness;

--- a/src/cuda/kernels.cuh
+++ b/src/cuda/kernels.cuh
@@ -167,19 +167,22 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 12) void preprocess_trace_tasks(
           tt.albedo_tex = device.scene.texture_assignments[t.object_maps].albedo_map;
           tt.id         = t_id;
 
-          float2 coords;
-          const float dist = bvh_triangle_intersection_uv(tt, task.origin, task.ray, coords);
+          // This feature does not work for displacement triangles
+          if (device.scene.texture_assignments[t.object_maps].normal_map == TEXTURE_NONE) {
+            float2 coords;
+            const float dist = bvh_triangle_intersection_uv(tt, task.origin, task.ray, coords);
 
-          if (dist < depth) {
-            const int alpha_result = bvh_triangle_intersection_alpha_test(tt, t_id, coords);
+            if (dist < depth) {
+              const int alpha_result = bvh_triangle_intersection_alpha_test(tt, t_id, coords);
 
-            if (alpha_result != 2) {
-              depth  = dist;
-              hit_id = t_id;
-            }
-            else if (device.iteration_type == TYPE_LIGHT) {
-              depth  = -1.0f;
-              hit_id = REJECT_HIT;
+              if (alpha_result != 2) {
+                depth  = dist;
+                hit_id = t_id;
+              }
+              else if (device.iteration_type == TYPE_LIGHT) {
+                depth  = -1.0f;
+                hit_id = REJECT_HIT;
+              }
             }
           }
         }

--- a/src/optixrt.c
+++ b/src/optixrt.c
@@ -168,7 +168,10 @@ void optixrt_init(RaytraceInstance* instance) {
   pipeline_compile_options.exceptionFlags                   = OPTIX_EXCEPTION_FLAG_NONE;
   pipeline_compile_options.pipelineLaunchParamsVariableName = "device";
   pipeline_compile_options.usesPrimitiveTypeFlags           = OPTIX_PRIMITIVE_TYPE_FLAGS_TRIANGLE;
-  pipeline_compile_options.allowOpacityMicromaps            = 1;
+
+  if (omm.opacityMicromapArray) {
+    pipeline_compile_options.allowOpacityMicromaps = 1;
+  }
 
   if (dmm.displacementMicromapArray) {
     pipeline_compile_options.usesPrimitiveTypeFlags |= OPTIX_PRIMITIVE_TYPE_FLAGS_DISPLACED_MICROMESH_TRIANGLE;

--- a/src/optixrt.c
+++ b/src/optixrt.c
@@ -33,7 +33,7 @@ void optixrt_init(RaytraceInstance* instance) {
   ////////////////////////////////////////////////////////////////////
 
   OptixBuildInputDisplacementMicromap dmm;
-  if (instance->device_info.rt_core_version >= 1) {
+  if ((instance->device_info.rt_core_version >= 1 && instance->optix_bvh.force_dmm_usage) || instance->device_info.rt_core_version >= 3) {
     dmm = micromap_displacement_build(instance);
   }
   else {


### PR DESCRIPTION
This pull request adds displacement mapping when using the OptiX BVH. This feature is in a rough state as only one kind of displacement micromaps is implemented, performance is poor on pre Ada Lovelace cards and handling discrepencies between geometry and shading normals is not perfect. However, the feature works for now and further improvements can be made if desired through individual commits so I merge this branch now.

Closes #67