### PR TITLE
Multiple Importance Sampling Weights for Variance Reduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,3 +230,4 @@ This is a list of papers I have used for this project so far. Note that some tec
 - L. Belcour and E. Heitz, _Lessons Learned and Improvements when Building Screen-Space Samplers with Blue-Noise Error Distribution_, ACM SIGGRAPH 2021 Talks, pp. 1-2, 2021.
 - K. Eto, Y. Tokuyoshi, _Bounded VNDF Sampling for Smith–GGX Reflections_, ACM SIGGRAPH Asia 2023 Technical Communications, pp. 1-4, 2023.
 - D. Sforza, F. Pellacini, _Enforcing Energy Preservation in Microfacet Models_, Smart Tools and Applications in Graphics - Eurographics Italian Chapter Conference, 2022.
+- R. West, I. Georgiev, T. Hachisuka, _Marginal Multiple Importance Sampling_, SIGGRAPH Asia 2022 Conference Papers, 2022.

--- a/include/structs.h
+++ b/include/structs.h
@@ -284,7 +284,7 @@ struct LightSample {
   uint32_t presampled_id;
   uint32_t id;
   float weight;
-  float sample_weight;
+  float target_pdf_normalization;
 } typedef LightSample;
 
 // TODO: Add colored dielectric as a flag
@@ -327,7 +327,7 @@ INTERLEAVED_STORAGE struct PackedGBufferData {
 } typedef PackedGBufferData;
 
 struct MISData {
-  float light_sampled_technique;
+  float light_target_pdf_normalization;
   float bsdf_marginal;
 } typedef MISData;
 

--- a/include/structs.h
+++ b/include/structs.h
@@ -326,6 +326,13 @@ INTERLEAVED_STORAGE struct PackedGBufferData {
   uint16_t ior_out;
 } typedef PackedGBufferData;
 
+struct MISData {
+  float light_sampled_technique;
+  float bsdf_antagonist_weight;
+  uint32_t bsdf_data;
+  uint32_t padding;
+} typedef MISData;
+
 ////////////////////////////////////////////////////////////////////
 // Kernel passing structs
 ////////////////////////////////////////////////////////////////////

--- a/include/structs.h
+++ b/include/structs.h
@@ -328,9 +328,7 @@ INTERLEAVED_STORAGE struct PackedGBufferData {
 
 struct MISData {
   float light_sampled_technique;
-  float bsdf_antagonist_weight;
-  uint32_t bsdf_data;
-  uint32_t padding;
+  float bsdf_marginal;
 } typedef MISData;
 
 ////////////////////////////////////////////////////////////////////

--- a/include/structs.h
+++ b/include/structs.h
@@ -307,6 +307,26 @@ struct GBufferData {
   uint32_t colored_dielectric;
 } typedef GBufferData;
 
+// For MIS, doesn't contain data that isn't used by light sampling.
+INTERLEAVED_STORAGE struct GBufferDataPacked {
+  uint32_t hit_id;
+  uint16_t albedo_r;
+  uint16_t albedo_g;
+  uint16_t albedo_b;
+  uint16_t albedo_a;
+  uint16_t roughness;
+  uint16_t metallic;
+  vec3 position;
+  vec3 V;
+  vec3 normal;
+  uint32_t rougness_metallic_packed;
+  uint32_t flags;
+  uint16_t ior_in;
+  uint16_t ior_out;
+  uint32_t padding;
+} typedef GBufferDataPacked;
+static_assert(sizeof(GBufferDataPacked) == 0x40);
+
 ////////////////////////////////////////////////////////////////////
 // Kernel passing structs
 ////////////////////////////////////////////////////////////////////

--- a/include/structs.h
+++ b/include/structs.h
@@ -6,6 +6,8 @@
 
 // This struct is stored as a struct of arrays, members are grouped into 16 bytes where possible. Padding is not required.
 #define INTERLEAVED_STORAGE
+// Round the size of an element in an interleaved buffer to the next multiple of 16 bytes
+#define INTERLEAVED_ALLOCATION_SIZE(X) ((X + 15u) & (~0xFu))
 
 /********************************************************
  * Vectors and matrices

--- a/include/structs.h
+++ b/include/structs.h
@@ -284,8 +284,10 @@ struct LightSample {
   uint32_t presampled_id;
   uint32_t id;
   float weight;
+  float sample_weight;
 } typedef LightSample;
 
+// TODO: Add colored dielectric as a flag
 enum GBufferFlags {
   G_BUFFER_REQUIRES_SAMPLING    = 0b1,
   G_BUFFER_VOLUME_HIT           = 0b10,
@@ -308,7 +310,7 @@ struct GBufferData {
 } typedef GBufferData;
 
 // For MIS, doesn't contain data that isn't used by light sampling.
-INTERLEAVED_STORAGE struct GBufferDataPacked {
+INTERLEAVED_STORAGE struct PackedGBufferData {
   uint32_t hit_id;
   uint16_t albedo_r;
   uint16_t albedo_g;
@@ -317,15 +319,12 @@ INTERLEAVED_STORAGE struct GBufferDataPacked {
   uint16_t roughness;
   uint16_t metallic;
   vec3 position;
-  vec3 V;
-  vec3 normal;
-  uint32_t rougness_metallic_packed;
+  vec3 V;       // TODO: Compress
+  vec3 normal;  // TODO: Compress
   uint32_t flags;
   uint16_t ior_in;
   uint16_t ior_out;
-  uint32_t padding;
-} typedef GBufferDataPacked;
-static_assert(sizeof(GBufferDataPacked) == 0x40);
+} typedef PackedGBufferData;
 
 ////////////////////////////////////////////////////////////////////
 // Kernel passing structs

--- a/include/utils.h
+++ b/include/utils.h
@@ -30,7 +30,7 @@
   }
 
 // Flags variables as unused so that no warning is emitted
-#define LUM_UNUSED(x) (void) (x);
+#define LUM_UNUSED(x) ((void) (x))
 
 #ifndef PI
 #define PI 3.141592653589f

--- a/include/utils.h
+++ b/include/utils.h
@@ -422,6 +422,7 @@ struct DevicePointers {
   RGBF* normal_buffer;
   RGBF* light_records;
   RGBF* bounce_records;
+  RGBF* bounce_records_history;
   PackedGBufferData* packed_gbuffer_history;
   XRGB8* buffer_8bit;
   vec3* raydir_buffer;
@@ -537,6 +538,7 @@ struct RaytraceInstance {
   DeviceBuffer* normal_buffer;
   DeviceBuffer* light_records;
   DeviceBuffer* bounce_records;
+  DeviceBuffer* bounce_records_history;
   DeviceBuffer* buffer_8bit;
   DeviceBuffer* light_candidates;
   DeviceBuffer* cloud_noise;

--- a/include/utils.h
+++ b/include/utils.h
@@ -422,6 +422,7 @@ struct DevicePointers {
   RGBF* normal_buffer;
   RGBF* light_records;
   RGBF* bounce_records;
+  PackedGBufferData* packed_gbuffer_history;
   XRGB8* buffer_8bit;
   vec3* raydir_buffer;
   float* mis_buffer;
@@ -548,6 +549,7 @@ struct RaytraceInstance {
   DeviceBuffer* bluenoise_1D;
   DeviceBuffer* bluenoise_2D;
   DeviceBuffer* mis_buffer;
+  DeviceBuffer* packed_gbuffer_history;
   int max_ray_depth;
   int reservoir_size;
   int offline_samples;

--- a/include/utils.h
+++ b/include/utils.h
@@ -426,7 +426,7 @@ struct DevicePointers {
   PackedGBufferData* packed_gbuffer_history;
   XRGB8* buffer_8bit;
   vec3* raydir_buffer;
-  float* mis_buffer;
+  MISData* mis_buffer;
   TraceResult* trace_result_buffer;
   uint8_t* state_buffer;
   DeviceTexture* albedo_atlas;

--- a/src/UI/UI_button.c
+++ b/src/UI/UI_button.c
@@ -6,7 +6,7 @@
 #include "utils.h"
 
 void handle_mouse_UIPanel_button(UI* ui, UIPanel* panel, int mouse_state, int x, int y) {
-  LUM_UNUSED(y)
+  LUM_UNUSED(y);
 
   if (x >= UI_WIDTH - 15 - panel->title->w && x <= UI_WIDTH - 5) {
     panel->hover = 1;

--- a/src/UI/UI_check.c
+++ b/src/UI/UI_check.c
@@ -6,8 +6,8 @@
 #include "utils.h"
 
 void handle_mouse_UIPanel_check(UI* ui, UIPanel* panel, int mouse_state, int x, int y) {
-  LUM_UNUSED(x)
-  LUM_UNUSED(y)
+  LUM_UNUSED(x);
+  LUM_UNUSED(y);
 
   panel->hover = 1;
 

--- a/src/UI/UI_slider.c
+++ b/src/UI/UI_slider.c
@@ -8,8 +8,8 @@
 #include "utils.h"
 
 void handle_mouse_UIPanel_slider(UI* ui, UIPanel* panel, int mouse_state, int x, int y) {
-  LUM_UNUSED(x)
-  LUM_UNUSED(y)
+  LUM_UNUSED(x);
+  LUM_UNUSED(y);
 
   panel->hover = 1;
 

--- a/src/UI/UI_tab.c
+++ b/src/UI/UI_tab.c
@@ -9,7 +9,7 @@
 #include "utils.h"
 
 void handle_mouse_UIPanel_tab(UI* ui, UIPanel* panel, int mouse_state, int x, int y) {
-  LUM_UNUSED(y)
+  LUM_UNUSED(y);
 
   panel->hover = 1;
 

--- a/src/cuda/brdf_unittest.cuh
+++ b/src/cuda/brdf_unittest.cuh
@@ -52,7 +52,8 @@ LUMINARY_KERNEL void brdf_unittest_kernel(float* bounce, float* light) {
       data.V = angles_to_direction(ran0.x, ran0.y);
 
       BSDFSampleInfo info;
-      bsdf_sample(data, make_ushort2(0, 0), info);
+      float bsdf_marginal;
+      bsdf_sample(data, make_ushort2(0, 0), info, bsdf_marginal);
 
       sum_bounce += luminance(info.weight);
 

--- a/src/cuda/bsdf.cuh
+++ b/src/cuda/bsdf.cuh
@@ -271,10 +271,10 @@ __device__ float bsdf_sample_marginal(const GBufferData data, const vec3 ray, co
 
   float sample_pdf;
   if (info.is_microfacet_based) {
-    sample_pdf = bsdf_microfacet_pdf(data, H.z, data_local.V.z);
+    sample_pdf = bsdf_microfacet_pdf(data_local, H.z, data_local.V.z);
   }
   else {
-    sample_pdf = bsdf_diffuse_pdf(data, ray_local.z);
+    sample_pdf = bsdf_diffuse_pdf(data_local, ray_local.z);
   }
 
   return marginal * sample_pdf;

--- a/src/cuda/bsdf.cuh
+++ b/src/cuda/bsdf.cuh
@@ -225,13 +225,13 @@ __device__ vec3 bsdf_sample(const GBufferData data, const ushort2 pixel, BSDFSam
 
   float sample_pdf;
   if (info.is_transparent_pass) {
-    sample_pdf = bsdf_microfacet_refraction_pdf(data, sampled_microfacet_refraction.z, data_local.V.z);
+    sample_pdf = bsdf_microfacet_refraction_pdf(data_local, sampled_microfacet_refraction.z, data_local.V.z);
   }
   else if (info.is_microfacet_based) {
-    sample_pdf = bsdf_microfacet_pdf(data, sampled_microfacet.z, data_local.V.z);
+    sample_pdf = bsdf_microfacet_pdf(data_local, sampled_microfacet.z, data_local.V.z);
   }
   else {
-    sample_pdf = bsdf_diffuse_pdf(data, ray_local.z);
+    sample_pdf = bsdf_diffuse_pdf(data_local, ray_local.z);
   }
 
   marginal = sample_pdf * choice_probability;

--- a/src/cuda/bsdf_utils.cuh
+++ b/src/cuda/bsdf_utils.cuh
@@ -29,10 +29,15 @@ struct BSDFDirectionalAlbedos {
   RGBF dielectric_inv;
 } typedef BSDFDirectionalAlbedos;
 
+enum BSDFMaterial { BSDF_CONDUCTOR = 0, BSDF_GLOSSY = 1, BSDF_DIELECTRIC = 2 } typedef BSDFMaterial;
+
 struct BSDFSampleInfo {
   RGBF weight;
   bool is_transparent_pass;
   bool is_microfacet_based;
+  // MIS sampled technique data
+  BSDFMaterial sampled_technique;
+  float antagonist_weight;
 } typedef BSDFSampleInfo;
 
 enum BSDFLUT { BSDF_LUT_SS = 0, BSDF_LUT_SPECULAR = 1, BSDF_LUT_DIELEC = 2, BSDF_LUT_DIELEC_INV = 3 } typedef BSDFLUT;

--- a/src/cuda/geometry.cuh
+++ b/src/cuda/geometry.cuh
@@ -202,8 +202,8 @@ LUMINARY_KERNEL void process_geometry_tasks() {
     vec3 bounce_ray = bsdf_sample(data, task.index, bounce_info, bsdf_marginal);
 
     uint32_t light_history_buffer_entry = LIGHT_ID_ANY;
-    float light_sample_marginal;
-    LightSample light = restir_sample_reservoir(data, record, task.index, light_sample_marginal);
+
+    LightSample light = restir_sample_reservoir(data, record, task.index);
 
     if (light.weight > 0.0f) {
       RGBF light_weight;
@@ -220,7 +220,7 @@ LUMINARY_KERNEL void process_geometry_tasks() {
       light_task.ray    = light_ray;
       light_task.index  = task.index;
 
-      const float light_mis_weight = mis_weight_light_sampled(data, light_ray, bounce_info, light_sample_marginal);
+      const float light_mis_weight = mis_weight_light_sampled(data, light_ray, bounce_info, light);
       store_RGBF(device.ptrs.light_records + pixel, scale_color(light_record, light_mis_weight));
       light_history_buffer_entry = light.id;
       store_trace_task(device.ptrs.light_trace + get_task_address(light_trace_count++), light_task);
@@ -248,8 +248,8 @@ LUMINARY_KERNEL void process_geometry_tasks() {
       store_trace_task(device.ptrs.bounce_trace + get_task_address(bounce_trace_count++), bounce_task);
 
       MISData mis_data;
-      mis_data.light_sampled_technique = light.sample_weight;
-      mis_data.bsdf_marginal           = bsdf_marginal;
+      mis_data.light_target_pdf_normalization = light.target_pdf_normalization;
+      mis_data.bsdf_marginal                  = bsdf_marginal;
 
       mis_store_data(data, record, mis_data, bounce_ray, pixel);
     }

--- a/src/cuda/geometry.cuh
+++ b/src/cuda/geometry.cuh
@@ -248,7 +248,7 @@ LUMINARY_KERNEL void process_geometry_tasks() {
       store_trace_task(device.ptrs.bounce_trace + get_task_address(bounce_trace_count++), bounce_task);
 
       MISData mis_data;
-      mis_data.light_sampled_technique = light.weight - light.sample_weight;
+      mis_data.light_sampled_technique = light.sample_weight;
       mis_data.bsdf_marginal           = bsdf_marginal;
 
       mis_store_data(data, record, mis_data, bounce_ray, pixel);

--- a/src/cuda/geometry.cuh
+++ b/src/cuda/geometry.cuh
@@ -198,7 +198,8 @@ LUMINARY_KERNEL void process_geometry_tasks() {
       write_albedo_buffer(opaque_color(data.albedo), pixel);
 
     BSDFSampleInfo bounce_info;
-    vec3 bounce_ray = bsdf_sample(data, task.index, bounce_info);
+    float bsdf_marginal;
+    vec3 bounce_ray = bsdf_sample(data, task.index, bounce_info, bsdf_marginal);
 
     uint32_t light_history_buffer_entry = LIGHT_ID_ANY;
     float light_sample_marginal;
@@ -246,7 +247,11 @@ LUMINARY_KERNEL void process_geometry_tasks() {
       store_RGBF(device.ptrs.bounce_records + pixel, bounce_record);
       store_trace_task(device.ptrs.bounce_trace + get_task_address(bounce_trace_count++), bounce_task);
 
-      mis_store_data(data, record, mis_gather_data(bounce_info, light.weight - light.sample_weight), bounce_ray, pixel);
+      MISData mis_data;
+      mis_data.light_sampled_technique = light.weight - light.sample_weight;
+      mis_data.bsdf_marginal           = bsdf_marginal;
+
+      mis_store_data(data, record, mis_data, bounce_ray, pixel);
     }
   }
 

--- a/src/cuda/geometry.cuh
+++ b/src/cuda/geometry.cuh
@@ -230,8 +230,8 @@ LUMINARY_KERNEL void process_geometry_tasks() {
 
     RGBF bounce_record = mul_color(record, bounce_info.weight);
 
-    const float shift           = (bounce_info.is_transparent_pass) ? -eps : eps;
-    const vec3 shifted_position = add_vector(data.position, scale_vector(data.V, shift * get_length(data.position)));
+    const float shift = (bounce_info.is_transparent_pass) ? -eps : eps;
+    data.position     = add_vector(data.position, scale_vector(data.V, shift * get_length(data.position)));
 
     if (bounce_info.is_transparent_pass) {
       const IORStackMethod ior_stack_method = (data.flags & G_BUFFER_REFRACTION_IS_INSIDE) ? IOR_STACK_METHOD_PULL : IOR_STACK_METHOD_PUSH;
@@ -239,7 +239,7 @@ LUMINARY_KERNEL void process_geometry_tasks() {
     }
 
     TraceTask bounce_task;
-    bounce_task.origin = shifted_position;
+    bounce_task.origin = data.position;
     bounce_task.ray    = bounce_ray;
     bounce_task.index  = task.index;
 

--- a/src/cuda/kernels.cuh
+++ b/src/cuda/kernels.cuh
@@ -35,8 +35,9 @@ LUMINARY_KERNEL void generate_trace_tasks() {
     device.ptrs.light_records[pixel]  = get_color(1.0f, 1.0f, 1.0f);
     device.ptrs.bounce_records[pixel] = get_color(1.0f, 1.0f, 1.0f);
     device.ptrs.frame_buffer[pixel]   = get_color(0.0f, 0.0f, 0.0f);
-    device.ptrs.mis_buffer[pixel]     = 1.0f;
     device.ptrs.state_buffer[pixel]   = 0;
+
+    mis_reset_data(pixel);
 
     if ((device.denoiser || device.aov_mode) && !device.temporal_frames) {
       device.ptrs.albedo_buffer[pixel] = get_color(0.0f, 0.0f, 0.0f);

--- a/src/cuda/memory.cuh
+++ b/src/cuda/memory.cuh
@@ -489,7 +489,7 @@ __device__ GBufferData load_gbuffer_data(const int pixel) {
 
 __device__ void store_mis_data(const MISData data, const int pixel) {
   float2 bytes;
-  bytes.x = data.light_sampled_technique;
+  bytes.x = data.light_target_pdf_normalization;
   bytes.y = data.bsdf_marginal;
 
   __stcs((float2*) (device.ptrs.mis_buffer + pixel), bytes);
@@ -499,8 +499,8 @@ __device__ MISData load_mis_data(const int pixel) {
   float2 bytes = __ldcs((float2*) (device.ptrs.mis_buffer + pixel));
 
   MISData data;
-  data.light_sampled_technique = bytes.x;
-  data.bsdf_marginal           = bytes.y;
+  data.light_target_pdf_normalization = bytes.x;
+  data.bsdf_marginal                  = bytes.y;
 
   return data;
 }

--- a/src/cuda/memory.cuh
+++ b/src/cuda/memory.cuh
@@ -488,21 +488,19 @@ __device__ GBufferData load_gbuffer_data(const int pixel) {
 }
 
 __device__ void store_mis_data(const MISData data, const int pixel) {
-  float4 bytes;
+  float2 bytes;
   bytes.x = data.light_sampled_technique;
-  bytes.y = data.bsdf_antagonist_weight;
-  bytes.z = __uint_as_float(data.bsdf_data);
+  bytes.y = data.bsdf_marginal;
 
-  __stcs((float4*) (device.ptrs.mis_buffer + pixel), bytes);
+  __stcs((float2*) (device.ptrs.mis_buffer + pixel), bytes);
 }
 
 __device__ MISData load_mis_data(const int pixel) {
-  float4 bytes = __ldcs((float4*) (device.ptrs.mis_buffer + pixel));
+  float2 bytes = __ldcs((float2*) (device.ptrs.mis_buffer + pixel));
 
   MISData data;
   data.light_sampled_technique = bytes.x;
-  data.bsdf_antagonist_weight  = bytes.y;
-  data.bsdf_data               = __float_as_uint(bytes.z);
+  data.bsdf_marginal           = bytes.y;
 
   return data;
 }

--- a/src/cuda/memory.cuh
+++ b/src/cuda/memory.cuh
@@ -325,8 +325,17 @@ __device__ TraversalTriangle load_traversal_triangle(const int offset) {
   return triangle;
 }
 
-__device__ void* triangle_get_entry_address(const uint32_t chunk, const uint32_t offset, const uint32_t id) {
-  return (void*) (((float*) device.scene.triangles) + (device.scene.triangle_data.triangle_count * chunk + id) * 4 + offset);
+__device__ const void* interleaved_buffer_get_entry_address(
+  const void* ptr, const uint32_t count, const uint32_t chunk, const uint32_t offset, const uint32_t id) {
+  return (const void*) (((const float*) ptr) + (count * chunk + id) * 4 + offset);
+}
+
+__device__ const void* pixel_buffer_get_entry_address(const void* ptr, const uint32_t chunk, const uint32_t offset, const uint32_t id) {
+  return interleaved_buffer_get_entry_address(ptr, device.width * device.height, chunk, offset, id);
+}
+
+__device__ const void* triangle_get_entry_address(const uint32_t chunk, const uint32_t offset, const uint32_t id) {
+  return interleaved_buffer_get_entry_address(device.scene.triangles, device.scene.triangle_data.triangle_count, chunk, offset, id);
 }
 
 __device__ UV load_triangle_tex_coords(const int offset, const float2 coords) {

--- a/src/cuda/mis.cuh
+++ b/src/cuda/mis.cuh
@@ -15,6 +15,10 @@ __device__ void mis_reset_data(const int pixel) {
   store_mis_data(invalid, pixel);
 }
 
+__device__ bool mis_data_is_invalid(const MISData data) {
+  return (data.light_sampled_technique == -1.0f || data.bsdf_marginal == FLT_MAX);
+}
+
 __device__ bool mis_propagate_data(const GBufferData data, const vec3 ray) {
   return (dot_product(ray, data.V) < 0.99f);
 }
@@ -38,6 +42,10 @@ __device__ float mis_weight_bsdf_sampled(const GBufferData data, const int pixel
   const GBufferData history_data = load_gbuffer_data(pixel);
   const RGBF history_records     = device.ptrs.bounce_records_history[pixel];
   const MISData mis_data         = load_mis_data(pixel);
+
+  // Invalid data means no MIS.
+  if (mis_data_is_invalid(mis_data))
+    return 1.0f;
 
   const float marginal_light = restir_sample_marginal(history_data, history_records, data, mis_data.light_sampled_technique);
 

--- a/src/cuda/mis.cuh
+++ b/src/cuda/mis.cuh
@@ -1,0 +1,73 @@
+#ifndef CU_MIS_H
+#define CU_MIS_H
+
+#include "bsdf.cuh"
+#include "math.cuh"
+#include "memory.cuh"
+#include "restir.cuh"
+#include "utils.cuh"
+
+__device__ void mis_reset_data(const int pixel) {
+  MISData invalid;
+  invalid.light_sampled_technique = -1.0f;
+  invalid.bsdf_antagonist_weight  = FLT_MAX;
+  invalid.bsdf_data               = 0;
+
+  store_mis_data(invalid, pixel);
+}
+
+__device__ MISData mis_gather_data(const BSDFSampleInfo info, const float light_sampled_technique) {
+  MISData data;
+  data.light_sampled_technique = light_sampled_technique;
+  data.bsdf_antagonist_weight  = info.antagonist_weight;
+  data.bsdf_data = info.sampled_technique | ((info.is_microfacet_based ? 1u : 0u) << 16) | ((info.is_transparent_pass ? 1u : 0u) << 24);
+
+  return data;
+}
+
+__device__ BSDFSampleInfo mis_bsdf_sample_info(const MISData data) {
+  BSDFSampleInfo info;
+
+  info.antagonist_weight   = data.bsdf_antagonist_weight;
+  info.weight              = get_color(1.0f, 1.0f, 1.0f);
+  info.sampled_technique   = (BSDFMaterial) (data.bsdf_data & 0xFF);
+  info.is_microfacet_based = ((data.bsdf_data >> 16) & 0xFF);
+  info.is_transparent_pass = ((data.bsdf_data >> 24) & 0xFF);
+
+  return info;
+}
+
+__device__ bool mis_propagate_data(const GBufferData data, const vec3 ray) {
+  return (dot_product(ray, data.V) < 0.99f);
+}
+
+__device__ void mis_store_data(const GBufferData data, const RGBF record, const MISData mis_data, const vec3 ray, const int pixel) {
+  if (mis_propagate_data(data, ray))
+    return;
+
+  store_gbuffer_data(data, pixel);
+  device.ptrs.bounce_records_history[pixel] = record;
+  store_mis_data(mis_data, pixel);
+}
+
+__device__ float mis_weight_light_sampled(const GBufferData data, const vec3 ray, const BSDFSampleInfo info, const float marginal_light) {
+  const float marginal_bsdf = bsdf_sample_marginal(data, ray, info);
+
+  return marginal_light / (marginal_light + marginal_bsdf);
+}
+
+__device__ float mis_weight_bsdf_sampled(const GBufferData data, const int pixel) {
+  const vec3 ray                 = scale_vector(data.V, -1.0f);
+  const GBufferData history_data = load_gbuffer_data(pixel);
+  const RGBF history_records     = device.ptrs.bounce_records_history[pixel];
+  const MISData mis_data         = load_mis_data(pixel);
+
+  const BSDFSampleInfo info = mis_bsdf_sample_info(mis_data);
+
+  const float marginal_bsdf  = bsdf_sample_marginal(history_data, ray, info);
+  const float marginal_light = restir_sample_marginal(history_data, history_records, data, mis_data.light_sampled_technique);
+
+  return marginal_bsdf / (marginal_bsdf + marginal_light);
+}
+
+#endif /* CU_MIS_H */

--- a/src/cuda/mis.cuh
+++ b/src/cuda/mis.cuh
@@ -22,7 +22,7 @@ __device__ bool mis_data_is_invalid(const MISData data) {
 }
 
 __device__ bool mis_propagate_data(const GBufferData data, const vec3 ray) {
-  return (dot_product(ray, data.V) < -0.99f);
+  return (dot_product(ray, data.V) < -0.999f);
 }
 
 __device__ void mis_store_data(const GBufferData data, const RGBF record, const MISData mis_data, const vec3 ray, const int pixel) {

--- a/src/cuda/mis.cuh
+++ b/src/cuda/mis.cuh
@@ -10,31 +10,9 @@
 __device__ void mis_reset_data(const int pixel) {
   MISData invalid;
   invalid.light_sampled_technique = -1.0f;
-  invalid.bsdf_antagonist_weight  = FLT_MAX;
-  invalid.bsdf_data               = 0;
+  invalid.bsdf_marginal           = FLT_MAX;
 
   store_mis_data(invalid, pixel);
-}
-
-__device__ MISData mis_gather_data(const BSDFSampleInfo info, const float light_sampled_technique) {
-  MISData data;
-  data.light_sampled_technique = light_sampled_technique;
-  data.bsdf_antagonist_weight  = info.antagonist_weight;
-  data.bsdf_data = info.sampled_technique | ((info.is_microfacet_based ? 1u : 0u) << 16) | ((info.is_transparent_pass ? 1u : 0u) << 24);
-
-  return data;
-}
-
-__device__ BSDFSampleInfo mis_bsdf_sample_info(const MISData data) {
-  BSDFSampleInfo info;
-
-  info.antagonist_weight   = data.bsdf_antagonist_weight;
-  info.weight              = get_color(1.0f, 1.0f, 1.0f);
-  info.sampled_technique   = (BSDFMaterial) (data.bsdf_data & 0xFF);
-  info.is_microfacet_based = ((data.bsdf_data >> 16) & 0xFF);
-  info.is_transparent_pass = ((data.bsdf_data >> 24) & 0xFF);
-
-  return info;
 }
 
 __device__ bool mis_propagate_data(const GBufferData data, const vec3 ray) {
@@ -57,17 +35,13 @@ __device__ float mis_weight_light_sampled(const GBufferData data, const vec3 ray
 }
 
 __device__ float mis_weight_bsdf_sampled(const GBufferData data, const int pixel) {
-  const vec3 ray                 = scale_vector(data.V, -1.0f);
   const GBufferData history_data = load_gbuffer_data(pixel);
   const RGBF history_records     = device.ptrs.bounce_records_history[pixel];
   const MISData mis_data         = load_mis_data(pixel);
 
-  const BSDFSampleInfo info = mis_bsdf_sample_info(mis_data);
-
-  const float marginal_bsdf  = bsdf_sample_marginal(history_data, ray, info);
   const float marginal_light = restir_sample_marginal(history_data, history_records, data, mis_data.light_sampled_technique);
 
-  return marginal_bsdf / (marginal_bsdf + marginal_light);
+  return mis_data.bsdf_marginal / (mis_data.bsdf_marginal + marginal_light);
 }
 
 #endif /* CU_MIS_H */

--- a/src/cuda/mis.cuh
+++ b/src/cuda/mis.cuh
@@ -22,7 +22,7 @@ __device__ bool mis_data_is_invalid(const MISData data) {
 }
 
 __device__ bool mis_propagate_data(const GBufferData data, const vec3 ray) {
-  return (dot_product(ray, data.V) < 0.99f);
+  return (dot_product(ray, data.V) < -0.99f);
 }
 
 __device__ void mis_store_data(const GBufferData data, const RGBF record, const MISData mis_data, const vec3 ray, const int pixel) {

--- a/src/cuda/ocean.cuh
+++ b/src/cuda/ocean.cuh
@@ -122,9 +122,7 @@ LUMINARY_KERNEL void process_ocean_tasks() {
     new_task.ray    = bounce_ray;
     new_task.index  = task.index;
 
-    // MIS weight must be propagated if the ray just passes through.
-    if (get_length(sub_vector(task.ray, bounce_ray)) > eps)
-      device.ptrs.mis_buffer[pixel] = 1.0f;
+    // TODO: Implement fallback for when no MIS
 
     store_RGBF(device.ptrs.bounce_records + pixel, record);
     store_trace_task(device.ptrs.bounce_trace + get_task_address(bounce_trace_count++), new_task);

--- a/src/cuda/ocean.cuh
+++ b/src/cuda/ocean.cuh
@@ -122,7 +122,7 @@ LUMINARY_KERNEL void process_ocean_tasks() {
     new_task.ray    = bounce_ray;
     new_task.index  = task.index;
 
-    // TODO: Implement fallback for when no MIS
+    mis_reset_data(pixel);
 
     store_RGBF(device.ptrs.bounce_records + pixel, record);
     store_trace_task(device.ptrs.bounce_trace + get_task_address(bounce_trace_count++), new_task);

--- a/src/cuda/particle.cuh
+++ b/src/cuda/particle.cuh
@@ -73,8 +73,7 @@ LUMINARY_KERNEL void particle_process_tasks() {
       store_trace_task(device.ptrs.bounce_trace + get_task_address(bounce_trace_count++), bounce_task);
     }
 
-    float light_sample_marginal;
-    const LightSample light = restir_sample_reservoir(data, record, task.index, light_sample_marginal);
+    const LightSample light = restir_sample_reservoir(data, record, task.index);
 
     uint32_t light_history_buffer_entry = LIGHT_ID_ANY;
 

--- a/src/cuda/particle.cuh
+++ b/src/cuda/particle.cuh
@@ -68,13 +68,13 @@ LUMINARY_KERNEL void particle_process_tasks() {
     bounce_task.ray    = bounce_ray;
     bounce_task.index  = task.index;
 
-    device.ptrs.mis_buffer[pixel] = 0.0f;
     if (validate_trace_task(bounce_task, bounce_record)) {
       store_RGBF(device.ptrs.bounce_records + pixel, bounce_record);
       store_trace_task(device.ptrs.bounce_trace + get_task_address(bounce_trace_count++), bounce_task);
     }
 
-    const LightSample light = restir_sample_reservoir(data, record, task.index);
+    float light_sample_marginal;
+    const LightSample light = restir_sample_reservoir(data, record, task.index, light_sample_marginal);
 
     uint32_t light_history_buffer_entry = LIGHT_ID_ANY;
 
@@ -90,7 +90,8 @@ LUMINARY_KERNEL void particle_process_tasks() {
       light_task.ray    = light_ray;
       light_task.index  = task.index;
 
-      store_RGBF(device.ptrs.light_records + pixel, light_record);
+      const float light_mis_weight = 1.0f;  // mis_weight_light_sampled(data, light_ray, bounce_info, light_sample_marginal);
+      store_RGBF(device.ptrs.light_records + pixel, scale_color(light_record, light_mis_weight));
       light_history_buffer_entry = light.id;
       store_trace_task(device.ptrs.light_trace + get_task_address(light_trace_count++), light_task);
     }

--- a/src/cuda/restir.cuh
+++ b/src/cuda/restir.cuh
@@ -199,14 +199,14 @@ __device__ vec3
 }
 
 __device__ float restir_target_pdf(
-  const GBufferData data, const vec3 ray, const RGBF record, const float solid_angle, const float sample_dist, const RGBF emission) {
+  const GBufferData data, const vec3 ray, const RGBF record, const float sample_dist, const RGBF emission) {
   RGBF bsdf_weight;
   if (data.flags & G_BUFFER_VOLUME_HIT) {
     bsdf_weight = volume_phase_evaluate(data, VOLUME_HIT_TYPE(data.hit_id), ray);
   }
   else {
     bool is_transparent_pass;
-    bsdf_weight = bsdf_evaluate(data, ray, BSDF_SAMPLING_GENERAL, is_transparent_pass, solid_angle);
+    bsdf_weight = bsdf_evaluate(data, ray, BSDF_SAMPLING_GENERAL, is_transparent_pass, 1.0f);
   }
 
   const RGBF color_value = mul_color(mul_color(emission, bsdf_weight), record);
@@ -245,7 +245,7 @@ __device__ float restir_sample_target_pdf(
 
   primitive_pdf = (solid_angle > 0.0f) ? 1.0f / solid_angle : 0.0f;
 
-  return restir_target_pdf(data, ray, record, solid_angle, sample_dist, emission);
+  return restir_target_pdf(data, ray, record, sample_dist, emission);
 }
 
 /**
@@ -407,7 +407,7 @@ __device__ float restir_sample_marginal(
   }
 
   float primitive_pdf = (solid_angle > 0.0f) ? 1.0f / solid_angle : 1.0f;
-  float target_pdf    = restir_target_pdf(data, ray, record, solid_angle, sample_dist, lum);
+  float target_pdf    = restir_target_pdf(data, ray, record, sample_dist, lum);
 
   float sampled_pdf = primitive_pdf * reservoir_pdf;
   float weight      = (sampled_pdf > 0.0f) ? target_pdf / sampled_pdf : 0.0f;

--- a/src/cuda/restir.cuh
+++ b/src/cuda/restir.cuh
@@ -353,6 +353,8 @@ __device__ LightSample restir_sample_reservoir(const GBufferData data, const RGB
 
   marginal = selection_sampled_pdf * (selected.sample_weight / selected.weight);
 
+  selected.sample_weight = selected.weight - selected.sample_weight;
+
   // Compute the shading weight of the selected light (Probability of selecting the light through WRS)
   if (selected.id == LIGHT_ID_NONE) {
     selected.weight = 0.0f;

--- a/src/cuda/restir.cuh
+++ b/src/cuda/restir.cuh
@@ -53,6 +53,7 @@ __device__ LightSample restir_sample_empty() {
   s.presampled_id = LIGHT_ID_NONE;
   s.id            = LIGHT_ID_NONE;
   s.weight        = 0.0f;
+  s.sample_weight = 0.0f;
 
   return s;
 }
@@ -277,6 +278,7 @@ __device__ LightSample restir_sample_reservoir(const GBufferData data, const RGB
       selected.id            = LIGHT_ID_SUN;
       selected.presampled_id = LIGHT_ID_SUN;
       selected.seed          = sampled.seed;
+      selected.sample_weight = weight;
       selection_target_pdf   = sampled_target_pdf;
     }
   }
@@ -298,6 +300,7 @@ __device__ LightSample restir_sample_reservoir(const GBufferData data, const RGB
       selected.id            = LIGHT_ID_TOY;
       selected.presampled_id = LIGHT_ID_TOY;
       selected.seed          = sampled.seed;
+      selected.sample_weight = weight;
       selection_target_pdf   = sampled_target_pdf;
     }
   }
@@ -333,6 +336,7 @@ __device__ LightSample restir_sample_reservoir(const GBufferData data, const RGB
       selected.id            = sampled.id;
       selected.presampled_id = sampled.presampled_id;
       selected.seed          = sampled.seed;
+      selected.sample_weight = weight;
       selection_target_pdf   = sampled_target_pdf;
     }
   }

--- a/src/cuda/restir.cuh
+++ b/src/cuda/restir.cuh
@@ -370,6 +370,9 @@ __device__ LightSample restir_sample_reservoir(const GBufferData data, const RGB
  */
 __device__ float restir_sample_marginal(
   const GBufferData data, const RGBF record, const GBufferData hit_data, const float target_pdf_normalization) {
+  if (target_pdf_normalization == 0.0f)
+    return 0.0f;
+
   const vec3 ray = scale_vector(hit_data.V, -1.0f);
 
   RGBF lum;

--- a/src/cuda/restir.cuh
+++ b/src/cuda/restir.cuh
@@ -392,16 +392,15 @@ __device__ float restir_sample_marginal(
     case HIT_TYPE_TOY:
       lum           = hit_data.emission;
       reservoir_pdf = 1.0f;
-
-      sample_dist = get_length(sub_vector(data.position, device.scene.toy.position));
-      solid_angle = toy_get_solid_angle(data.position);
+      sample_dist   = get_length(sub_vector(data.position, device.scene.toy.position));
+      solid_angle   = toy_get_solid_angle(data.position);
       break;
     default:
       lum           = hit_data.emission;
       reservoir_pdf = (1.0f / device.scene.triangle_lights_count);
       sample_dist   = get_length(sub_vector(hit_data.position, device.scene.toy.position));
       // TODO: Use actual face normal and not the shading normal
-      restir_triangle_properties(hit_data.position, ray, data.normal, data.position, solid_angle, sample_dist);
+      restir_triangle_properties(hit_data.position, ray, hit_data.normal, data.position, solid_angle, sample_dist);
       break;
   }
 
@@ -412,7 +411,7 @@ __device__ float restir_sample_marginal(
   float weight      = (sampled_pdf > 0.0f) ? target_pdf / sampled_pdf : 0.0f;
 
   // Probability of sampling from reservoir and probability of choosing this sample based on the sampled technique.
-  return sampled_pdf * (weight / (weight + sampled_technique));
+  return (weight > 0.0f) ? sampled_pdf * (weight / (weight + sampled_technique)) : 0.0f;
 }
 
 LUMINARY_KERNEL void restir_candidates_pool_generation() {

--- a/src/cuda/toy.cuh
+++ b/src/cuda/toy.cuh
@@ -60,7 +60,7 @@ LUMINARY_KERNEL void process_toy_tasks() {
     ToyTask task    = load_toy_task(device.trace_tasks + get_task_address(task_offset + i));
     const int pixel = task.index.y * device.width + task.index.x;
 
-    const GBufferData data = toy_generate_g_buffer(task, pixel);
+    GBufferData data = toy_generate_g_buffer(task, pixel);
 
     RGBF record = load_RGBF(device.records + pixel);
 
@@ -115,8 +115,8 @@ LUMINARY_KERNEL void process_toy_tasks() {
 
     RGBF bounce_record = mul_color(record, bounce_info.weight);
 
-    const float shift           = (bounce_info.is_transparent_pass) ? -eps : eps;
-    const vec3 shifted_position = add_vector(data.position, scale_vector(data.V, shift * get_length(data.position)));
+    const float shift = (bounce_info.is_transparent_pass) ? -eps : eps;
+    data.position     = add_vector(data.position, scale_vector(data.V, shift * get_length(data.position)));
 
     if (bounce_info.is_transparent_pass) {
       const IORStackMethod ior_stack_method = (data.flags & G_BUFFER_REFRACTION_IS_INSIDE) ? IOR_STACK_METHOD_PULL : IOR_STACK_METHOD_PUSH;
@@ -124,7 +124,7 @@ LUMINARY_KERNEL void process_toy_tasks() {
     }
 
     TraceTask bounce_task;
-    bounce_task.origin = shifted_position;
+    bounce_task.origin = data.position;
     bounce_task.ray    = bounce_ray;
     bounce_task.index  = task.index;
 

--- a/src/cuda/toy.cuh
+++ b/src/cuda/toy.cuh
@@ -134,7 +134,7 @@ LUMINARY_KERNEL void process_toy_tasks() {
       store_trace_task(device.ptrs.bounce_trace + get_task_address(bounce_trace_count++), bounce_task);
 
       MISData mis_data;
-      mis_data.light_sampled_technique = light.weight - light.sample_weight;
+      mis_data.light_sampled_technique = light.sample_weight;
       mis_data.bsdf_marginal           = bsdf_marginal;
 
       mis_store_data(data, record, mis_data, bounce_ray, pixel);

--- a/src/cuda/toy.cuh
+++ b/src/cuda/toy.cuh
@@ -83,7 +83,8 @@ LUMINARY_KERNEL void process_toy_tasks() {
       write_albedo_buffer(opaque_color(data.albedo), pixel);
 
     BSDFSampleInfo bounce_info;
-    vec3 bounce_ray = bsdf_sample(data, task.index, bounce_info);
+    float bsdf_marginal;
+    vec3 bounce_ray = bsdf_sample(data, task.index, bounce_info, bsdf_marginal);
 
     uint32_t light_history_buffer_entry = LIGHT_ID_ANY;
 
@@ -132,7 +133,11 @@ LUMINARY_KERNEL void process_toy_tasks() {
       store_RGBF(device.ptrs.bounce_records + pixel, bounce_record);
       store_trace_task(device.ptrs.bounce_trace + get_task_address(bounce_trace_count++), bounce_task);
 
-      mis_store_data(data, record, mis_gather_data(bounce_info, light.weight - light.sample_weight), bounce_ray, pixel);
+      MISData mis_data;
+      mis_data.light_sampled_technique = light.weight - light.sample_weight;
+      mis_data.bsdf_marginal           = bsdf_marginal;
+
+      mis_store_data(data, record, mis_data, bounce_ray, pixel);
     }
   }
 

--- a/src/cuda/toy.cuh
+++ b/src/cuda/toy.cuh
@@ -88,8 +88,7 @@ LUMINARY_KERNEL void process_toy_tasks() {
 
     uint32_t light_history_buffer_entry = LIGHT_ID_ANY;
 
-    float light_sample_marginal;
-    LightSample light = restir_sample_reservoir(data, record, task.index, light_sample_marginal);
+    LightSample light = restir_sample_reservoir(data, record, task.index);
 
     if (light.weight > 0.0f) {
       RGBF light_weight;
@@ -106,7 +105,7 @@ LUMINARY_KERNEL void process_toy_tasks() {
       light_task.ray    = light_ray;
       light_task.index  = task.index;
 
-      const float light_mis_weight = mis_weight_light_sampled(data, light_ray, bounce_info, light_sample_marginal);
+      const float light_mis_weight = mis_weight_light_sampled(data, light_ray, bounce_info, light);
       store_RGBF(device.ptrs.light_records + pixel, scale_color(light_record, light_mis_weight));
       light_history_buffer_entry = light.id;
       store_trace_task(device.ptrs.light_trace + get_task_address(light_trace_count++), light_task);
@@ -134,8 +133,8 @@ LUMINARY_KERNEL void process_toy_tasks() {
       store_trace_task(device.ptrs.bounce_trace + get_task_address(bounce_trace_count++), bounce_task);
 
       MISData mis_data;
-      mis_data.light_sampled_technique = light.sample_weight;
-      mis_data.bsdf_marginal           = bsdf_marginal;
+      mis_data.light_target_pdf_normalization = light.target_pdf_normalization;
+      mis_data.bsdf_marginal                  = bsdf_marginal;
 
       mis_store_data(data, record, mis_data, bounce_ray, pixel);
     }

--- a/src/cuda/toy.cuh
+++ b/src/cuda/toy.cuh
@@ -70,7 +70,7 @@ LUMINARY_KERNEL void process_toy_tasks() {
       RGBF emission = mul_color(data.emission, record);
 
       if (device.iteration_type == TYPE_BOUNCE) {
-        const float mis_weight = device.ptrs.mis_buffer[pixel];
+        const float mis_weight = mis_weight_bsdf_sampled(data, pixel);
         emission               = scale_color(emission, mis_weight);
       }
 
@@ -82,13 +82,13 @@ LUMINARY_KERNEL void process_toy_tasks() {
     if (!material_is_mirror(data.roughness, data.metallic))
       write_albedo_buffer(opaque_color(data.albedo), pixel);
 
-    float bounce_mis_weight = 1.0f;
-
     BSDFSampleInfo bounce_info;
     vec3 bounce_ray = bsdf_sample(data, task.index, bounce_info);
 
     uint32_t light_history_buffer_entry = LIGHT_ID_ANY;
-    LightSample light                   = restir_sample_reservoir(data, record, task.index);
+
+    float light_sample_marginal;
+    LightSample light = restir_sample_reservoir(data, record, task.index, light_sample_marginal);
 
     if (light.weight > 0.0f) {
       RGBF light_weight;
@@ -105,8 +105,7 @@ LUMINARY_KERNEL void process_toy_tasks() {
       light_task.ray    = light_ray;
       light_task.index  = task.index;
 
-      const float light_mis_weight = (bounce_info.is_microfacet_based) ? data.roughness * data.roughness : 1.0f;
-      bounce_mis_weight            = 1.0f - light_mis_weight;
+      const float light_mis_weight = mis_weight_light_sampled(data, light_ray, bounce_info, light_sample_marginal);
       store_RGBF(device.ptrs.light_records + pixel, scale_color(light_record, light_mis_weight));
       light_history_buffer_entry = light.id;
       store_trace_task(device.ptrs.light_trace + get_task_address(light_trace_count++), light_task);
@@ -133,9 +132,7 @@ LUMINARY_KERNEL void process_toy_tasks() {
       store_RGBF(device.ptrs.bounce_records + pixel, bounce_record);
       store_trace_task(device.ptrs.bounce_trace + get_task_address(bounce_trace_count++), bounce_task);
 
-      // MIS weight must be propagated if the ray just passes through.
-      if (get_length(sub_vector(task.ray, bounce_ray)) > eps)
-        device.ptrs.mis_buffer[pixel] = bounce_mis_weight;
+      mis_store_data(data, record, mis_gather_data(bounce_info, light.weight - light.sample_weight), bounce_ray, pixel);
     }
   }
 

--- a/src/cuda/volume.cuh
+++ b/src/cuda/volume.cuh
@@ -192,8 +192,7 @@ LUMINARY_KERNEL void volume_process_tasks() {
 
     const GBufferData data = volume_generate_g_buffer(task, pixel, volume);
 
-    float light_sample_marginal;
-    LightSample light = restir_sample_reservoir(data, record, task.index, light_sample_marginal);
+    LightSample light = restir_sample_reservoir(data, record, task.index);
 
     uint32_t light_history_buffer_entry = LIGHT_ID_ANY;
 

--- a/src/cuda/volume.cuh
+++ b/src/cuda/volume.cuh
@@ -40,7 +40,7 @@ __device__ GBufferData volume_generate_g_buffer(const VolumeTask task, const int
   data.normal    = get_vector(0.0f, 0.0f, 0.0f);
   data.position  = task.position;
   data.V         = scale_vector(task.ray, -1.0f);
-  data.roughness = 1.0f;
+  data.roughness = device.scene.fog.droplet_diameter;
   data.metallic  = 0.0f;
   data.flags     = G_BUFFER_REQUIRES_SAMPLING | G_BUFFER_VOLUME_HIT;
 
@@ -171,26 +171,11 @@ LUMINARY_KERNEL void volume_process_tasks() {
 
     write_albedo_buffer(get_color(0.0f, 0.0f, 0.0f), pixel);
 
-    const float random_choice = quasirandom_sequence_1D(QUASI_RANDOM_TARGET_BOUNCE_DIR_CHOICE, task.index);
-    const float2 random_dir   = quasirandom_sequence_2D(QUASI_RANDOM_TARGET_BOUNCE_DIR, task.index);
-
-    const vec3 bounce_ray = (volume.type == VOLUME_TYPE_FOG)
-                              ? jendersie_eon_phase_sample(task.ray, device.scene.fog.droplet_diameter, random_dir, random_choice)
-                              : ocean_phase_sampling(task.ray, random_dir, random_choice);
-
-    RGBF bounce_record = record;
-
-    TraceTask bounce_task;
-    bounce_task.origin = task.position;
-    bounce_task.ray    = bounce_ray;
-    bounce_task.index  = task.index;
-
-    if (validate_trace_task(bounce_task, bounce_record)) {
-      store_RGBF(device.ptrs.bounce_records + pixel, bounce_record);
-      store_trace_task(device.ptrs.bounce_trace + get_task_address(bounce_trace_count++), bounce_task);
-    }
-
     const GBufferData data = volume_generate_g_buffer(task, pixel, volume);
+
+    BSDFSampleInfo bounce_info;
+    float bsdf_marginal;
+    const vec3 bounce_ray = bsdf_sample(data, task.index, bounce_info, bsdf_marginal);
 
     LightSample light = restir_sample_reservoir(data, record, task.index);
 
@@ -208,13 +193,31 @@ LUMINARY_KERNEL void volume_process_tasks() {
       light_task.ray    = light_ray;
       light_task.index  = task.index;
 
-      const float light_mis_weight = 1.0f;  // mis_weight_light_sampled(data, light_ray, bounce_info, light_sample_marginal);
+      const float light_mis_weight = mis_weight_light_sampled(data, light_ray, bounce_info, light);
       store_RGBF(device.ptrs.light_records + pixel, scale_color(light_record, light_mis_weight));
       light_history_buffer_entry = light.id;
       store_trace_task(device.ptrs.light_trace + get_task_address(light_trace_count++), light_task);
     }
 
     device.ptrs.light_sample_history[pixel] = light_history_buffer_entry;
+
+    RGBF bounce_record = record;
+
+    TraceTask bounce_task;
+    bounce_task.origin = task.position;
+    bounce_task.ray    = bounce_ray;
+    bounce_task.index  = task.index;
+
+    if (validate_trace_task(bounce_task, bounce_record)) {
+      MISData mis_data;
+      mis_data.light_target_pdf_normalization = light.target_pdf_normalization;
+      mis_data.bsdf_marginal                  = bsdf_marginal;
+
+      mis_store_data(data, record, mis_data, bounce_ray, pixel);
+
+      store_RGBF(device.ptrs.bounce_records + pixel, bounce_record);
+      store_trace_task(device.ptrs.bounce_trace + get_task_address(bounce_trace_count++), bounce_task);
+    }
   }
 
   device.ptrs.light_trace_count[THREAD_ID]  = light_trace_count;

--- a/src/raytrace.c
+++ b/src/raytrace.c
@@ -696,7 +696,7 @@ void raytrace_allocate_buffers(RaytraceInstance* instance) {
   device_buffer_malloc(instance->light_records, sizeof(RGBF), amount);
   device_buffer_malloc(instance->bounce_records, sizeof(RGBF), amount);
   device_buffer_malloc(instance->bounce_records_history, sizeof(RGBF), amount);
-  device_buffer_malloc(instance->mis_buffer, sizeof(float), amount);
+  device_buffer_malloc(instance->mis_buffer, sizeof(MISData), amount);
   device_buffer_malloc(instance->packed_gbuffer_history, sizeof(PackedGBufferData), amount);
 
   if (instance->denoiser || instance->aov_mode) {
@@ -781,7 +781,7 @@ void raytrace_update_device_pointers(RaytraceInstance* instance) {
   ptrs.bsdf_energy_lut           = (DeviceTexture*) device_buffer_get_pointer(instance->bsdf_energy_lut);
   ptrs.bluenoise_1D              = (uint16_t*) device_buffer_get_pointer(instance->bluenoise_1D);
   ptrs.bluenoise_2D              = (uint32_t*) device_buffer_get_pointer(instance->bluenoise_2D);
-  ptrs.mis_buffer                = (float*) device_buffer_get_pointer(instance->mis_buffer);
+  ptrs.mis_buffer                = (MISData*) device_buffer_get_pointer(instance->mis_buffer);
   ptrs.packed_gbuffer_history    = (PackedGBufferData*) device_buffer_get_pointer(instance->packed_gbuffer_history);
 
   device_update_symbol(ptrs, ptrs);

--- a/src/raytrace.c
+++ b/src/raytrace.c
@@ -545,6 +545,7 @@ void raytrace_init(RaytraceInstance** _instance, General general, TextureAtlas t
   device_buffer_init(&instance->normal_buffer);
   device_buffer_init(&instance->light_records);
   device_buffer_init(&instance->bounce_records);
+  device_buffer_init(&instance->bounce_records_history);
   device_buffer_init(&instance->buffer_8bit);
   device_buffer_init(&instance->raydir_buffer);
   device_buffer_init(&instance->trace_result_buffer);
@@ -694,6 +695,7 @@ void raytrace_allocate_buffers(RaytraceInstance* instance) {
   device_buffer_malloc(instance->frame_output, sizeof(RGBF), output_amount);
   device_buffer_malloc(instance->light_records, sizeof(RGBF), amount);
   device_buffer_malloc(instance->bounce_records, sizeof(RGBF), amount);
+  device_buffer_malloc(instance->bounce_records_history, sizeof(RGBF), amount);
   device_buffer_malloc(instance->mis_buffer, sizeof(float), amount);
   device_buffer_malloc(instance->packed_gbuffer_history, sizeof(PackedGBufferData), amount);
 
@@ -760,6 +762,7 @@ void raytrace_update_device_pointers(RaytraceInstance* instance) {
   ptrs.normal_buffer             = (RGBF*) device_buffer_get_pointer(instance->normal_buffer);
   ptrs.light_records             = (RGBF*) device_buffer_get_pointer(instance->light_records);
   ptrs.bounce_records            = (RGBF*) device_buffer_get_pointer(instance->bounce_records);
+  ptrs.bounce_records_history    = (RGBF*) device_buffer_get_pointer(instance->bounce_records_history);
   ptrs.buffer_8bit               = (XRGB8*) device_buffer_get_pointer(instance->buffer_8bit);
   ptrs.albedo_atlas              = (DeviceTexture*) device_buffer_get_pointer(instance->tex_atlas.albedo);
   ptrs.luminance_atlas           = (DeviceTexture*) device_buffer_get_pointer(instance->tex_atlas.luminance);
@@ -805,6 +808,7 @@ void raytrace_free_work_buffers(RaytraceInstance* instance) {
   device_buffer_free(instance->frame_variance);
   device_buffer_free(instance->light_records);
   device_buffer_free(instance->bounce_records);
+  device_buffer_free(instance->bounce_records_history);
   device_buffer_free(instance->light_sample_history);
   device_buffer_free(instance->raydir_buffer);
   device_buffer_free(instance->trace_result_buffer);

--- a/src/raytrace.c
+++ b/src/raytrace.c
@@ -560,6 +560,7 @@ void raytrace_init(RaytraceInstance** _instance, General general, TextureAtlas t
   device_buffer_init(&instance->bluenoise_1D);
   device_buffer_init(&instance->bluenoise_2D);
   device_buffer_init(&instance->mis_buffer);
+  device_buffer_init(&instance->packed_gbuffer_history);
 
   device_buffer_malloc(instance->buffer_8bit, sizeof(XRGB8), instance->width * instance->height);
 
@@ -694,6 +695,7 @@ void raytrace_allocate_buffers(RaytraceInstance* instance) {
   device_buffer_malloc(instance->light_records, sizeof(RGBF), amount);
   device_buffer_malloc(instance->bounce_records, sizeof(RGBF), amount);
   device_buffer_malloc(instance->mis_buffer, sizeof(float), amount);
+  device_buffer_malloc(instance->packed_gbuffer_history, sizeof(PackedGBufferData), amount);
 
   if (instance->denoiser || instance->aov_mode) {
     device_buffer_malloc(instance->albedo_buffer, sizeof(RGBF), amount);
@@ -777,6 +779,7 @@ void raytrace_update_device_pointers(RaytraceInstance* instance) {
   ptrs.bluenoise_1D              = (uint16_t*) device_buffer_get_pointer(instance->bluenoise_1D);
   ptrs.bluenoise_2D              = (uint32_t*) device_buffer_get_pointer(instance->bluenoise_2D);
   ptrs.mis_buffer                = (float*) device_buffer_get_pointer(instance->mis_buffer);
+  ptrs.packed_gbuffer_history    = (PackedGBufferData*) device_buffer_get_pointer(instance->packed_gbuffer_history);
 
   device_update_symbol(ptrs, ptrs);
   log_message("Updated device pointers.");
@@ -807,6 +810,7 @@ void raytrace_free_work_buffers(RaytraceInstance* instance) {
   device_buffer_free(instance->trace_result_buffer);
   device_buffer_free(instance->state_buffer);
   device_buffer_free(instance->mis_buffer);
+  device_buffer_free(instance->packed_gbuffer_history);
 
   gpuErrchk(cudaDeviceSynchronize());
 }

--- a/src/struct_interleaving.c
+++ b/src/struct_interleaving.c
@@ -51,11 +51,8 @@ void struct_triangles_interleave(Triangle* dst, Triangle* src, uint32_t count) {
 
     offset += count * 4;
 
-    dst_uint[offset + i] = triangle.material_id;
-
-    offset += count;
-
-    dst_uint[offset + i] = triangle.light_id;
+    dst_uint[offset + i * 4 + 0] = triangle.material_id;
+    dst_uint[offset + i * 4 + 1] = triangle.light_id;
   }
 }
 
@@ -110,11 +107,8 @@ void struct_triangles_deinterleave(Triangle* dst, Triangle* src, uint32_t count)
 
     offset += count * 4;
 
-    triangle.material_id = src_uint[offset + i];
-
-    offset += count;
-
-    triangle.light_id = src_uint[offset + i];
+    triangle.material_id = src_uint[offset + i * 4 + 0];
+    triangle.light_id    = src_uint[offset + i * 4 + 1];
 
     dst[i] = triangle;
   }


### PR DESCRIPTION
I finally tackled implementing some classic MIS weights. However, since non of my sampling methods have computable PDFs, this is a bit more trickier than usual. Essentially, I was able to approximate the BSDF sampling PDF using the marginal approximation from the 2022 paper and by understanding the ReSTIR sampling weight and using it to obtain the PDF in expectation. All in all the improvements are spotty. Sun lit scenes have completely firefly less direct lighting while many light scenes are mixed with some surfaces being really clean and other being really noisy. Good thing is that many light scenes do given enough samples now reasonably converge to a firefly less image. However, indirect lighting can still causing lots of fireflies especially in volumes and in the presence of caustics.

I have now realized that I will not be able to get rid of the firefly clamping (unless I start doing crazy rewrites for a MIS indirect lighting which won't happen in many years to come). I can make huge gains now by implementing support for multiple light rays for each pixel. This will improve the MIS weight approximation and will in general be more efficient since the bounce rays are the most expensive part. Lots of work will be required for that though.