### PR TITLE
Added support for various image file formats

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "optix-dev"]
 	path = src/luminary/optix-dev
 	url = https://github.com/NVIDIA/optix-dev.git
+[submodule "src/luminary/stb"]
+	path = src/luminary/stb
+	url = https://github.com/nothings/stb.git

--- a/LumFileDocsV4.md
+++ b/LumFileDocsV4.md
@@ -451,32 +451,7 @@ Meshes must be in the Wavefront OBJ (`*.obj`) file format. Geometric vertices, t
 
 >📝 A common cause of light leaking / broken lighting is unrealistic vertex normals. Issues appear if the vertex normals represent a surface that is too different from the actual geometry. Performing steps like edge splitting often alleviate this issue at the cost of a higher triangle count.
 
-# Textures
-
-Textures must be in the Portable Network Graphics (`*.png`) file format. They need to have 8 bit channel depth. Supported color formats are `Truecolor` (RGB) and `Truecolor with alpha` (RGBA). They may use filters but may not be interlaced. Textures are used in three different ways:
-
- - Albedo Textures
-   - Red: Red Color
-   - Green: Green Color
-   - Blue: Blue Color
-   - Alpha: Transparency
- - Luminance Textures
-   - Red: Emission Red Color
-   - Green: Emission Green Color
-   - Blue: Emission Blue Color
-   - Alpha: Emission Intensity [0,1]
- - Material Textures
-   - Red: Roughness
-   - Green: Metallic
-   - Blue: Unused
-   - Alpha: Unused
- - Normal Textures (OpenGL format)
-   - Red: Tangent X
-   - Green: Tangent Y
-   - Blue: Tangent Z
-   - Alpha: Displacement
-
->📝 Textures must contain gamma information if they are not encoded linearly. Note that GIMP does not correctly export the correct gamma value. Hence, it is important to uncheck "Save gamma" during png export ([See Thread](https://gitlab.gnome.org/GNOME/gimp/-/issues/5363)). If textures are not displayed correctly, make sure that the gamma value used in the png file correctly approximates the color profile otherwise defined in the file.
+# Materials
 
 Material properties are to be referenced in the `*.mtl` as follows:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The goal is to build an offline renderer that achieves high quality final render
 
 >📝 Luminary currently transitions to a new scene description format, this new format is not yet available. Luminary can still parse the old format but it can no longer export scenes in the old format.
 
-The scene is described through the Luminary Scene Description format (`*.lum`). The format is documented in the [Luminary File Documentations](LumFileDocs.md). It is possible to specify a `*.obj` file instead of a `*.lum` file. This will load the mesh and use the default settings. Then one can make changes to the settings and automatically generate a `*.lum` file.
+The scene is described through the Luminary Scene Description format (`*.lum`). The format is documented in the [Luminary File Documentations](LumFileDocsV4.md). It is possible to specify a `*.obj` file instead of a `*.lum` file. This will load the mesh and use the default settings. Then one can make changes to the settings and automatically generate a `*.lum` file.
 
 Luminary comes with its own frontend called `Mandarin Duck`. You can run Mandarin Duck through:
 
@@ -78,7 +78,7 @@ Requirements:
 - AVX2 compatible CPU
 - Supported Nvidia GPU (Pascal or later)
 
->📝 `zlib`, `qoi`, `Ceb` and `OptiX` come as git submodules. Make sure to clone the submodules by using `git submodule update --init` after cloning Luminary.
+>📝 `zlib`, `qoi`, `Ceb`, `stb` and `OptiX` come as git submodules. Make sure to clone the submodules by using `git submodule update --init` after cloning Luminary.
 
 ## CMake Options
 | Option                     | Description

--- a/include/luminary/structs.h
+++ b/include/luminary/structs.h
@@ -343,6 +343,7 @@ LUMINARY_API struct LuminaryMaterial {
   bool metallic;
   bool colored_transparency;
   bool roughness_as_smoothness;
+  bool normal_map_is_compressed;
   uint16_t albedo_tex;
   uint16_t luminance_tex;
   uint16_t roughness_tex;

--- a/src/luminary/device/device_bsdf.c
+++ b/src/luminary/device/device_bsdf.c
@@ -27,27 +27,28 @@ LuminaryResult bsdf_lut_create(BSDFLUT** lut) {
   __FAILURE_HANDLE(texture_create(&(*lut)->dielectric));
   __FAILURE_HANDLE(texture_create(&(*lut)->dielectric_inv));
 
-  __FAILURE_HANDLE(texture_fill((*lut)->conductor, BSDF_LUT_SIZE, BSDF_LUT_SIZE, 1, conductor_data, TexDataUINT16, 1));
-  __FAILURE_HANDLE(texture_fill((*lut)->specular, BSDF_LUT_SIZE, BSDF_LUT_SIZE, 1, specular_data, TexDataUINT16, 1));
-  __FAILURE_HANDLE(texture_fill((*lut)->dielectric, BSDF_LUT_SIZE, BSDF_LUT_SIZE, BSDF_LUT_SIZE, dielectric_data, TexDataUINT16, 1));
+  __FAILURE_HANDLE(texture_fill((*lut)->conductor, BSDF_LUT_SIZE, BSDF_LUT_SIZE, 1, conductor_data, TEXTURE_DATA_TYPE_U16, 1));
+  __FAILURE_HANDLE(texture_fill((*lut)->specular, BSDF_LUT_SIZE, BSDF_LUT_SIZE, 1, specular_data, TEXTURE_DATA_TYPE_U16, 1));
   __FAILURE_HANDLE(
-    texture_fill((*lut)->dielectric_inv, BSDF_LUT_SIZE, BSDF_LUT_SIZE, BSDF_LUT_SIZE, dielectric_inv_data, TexDataUINT16, 1));
+    texture_fill((*lut)->dielectric, BSDF_LUT_SIZE, BSDF_LUT_SIZE, BSDF_LUT_SIZE, dielectric_data, TEXTURE_DATA_TYPE_U16, 1));
+  __FAILURE_HANDLE(
+    texture_fill((*lut)->dielectric_inv, BSDF_LUT_SIZE, BSDF_LUT_SIZE, BSDF_LUT_SIZE, dielectric_inv_data, TEXTURE_DATA_TYPE_U16, 1));
 
-  (*lut)->conductor->wrap_mode_R = TexModeClamp;
-  (*lut)->conductor->wrap_mode_S = TexModeClamp;
-  (*lut)->conductor->wrap_mode_T = TexModeClamp;
+  (*lut)->conductor->wrap_mode_R = TEXTURE_WRAPPING_MODE_CLAMP;
+  (*lut)->conductor->wrap_mode_S = TEXTURE_WRAPPING_MODE_CLAMP;
+  (*lut)->conductor->wrap_mode_T = TEXTURE_WRAPPING_MODE_CLAMP;
 
-  (*lut)->specular->wrap_mode_R = TexModeClamp;
-  (*lut)->specular->wrap_mode_S = TexModeClamp;
-  (*lut)->specular->wrap_mode_T = TexModeClamp;
+  (*lut)->specular->wrap_mode_R = TEXTURE_WRAPPING_MODE_CLAMP;
+  (*lut)->specular->wrap_mode_S = TEXTURE_WRAPPING_MODE_CLAMP;
+  (*lut)->specular->wrap_mode_T = TEXTURE_WRAPPING_MODE_CLAMP;
 
-  (*lut)->dielectric->wrap_mode_R = TexModeClamp;
-  (*lut)->dielectric->wrap_mode_S = TexModeClamp;
-  (*lut)->dielectric->wrap_mode_T = TexModeClamp;
+  (*lut)->dielectric->wrap_mode_R = TEXTURE_WRAPPING_MODE_CLAMP;
+  (*lut)->dielectric->wrap_mode_S = TEXTURE_WRAPPING_MODE_CLAMP;
+  (*lut)->dielectric->wrap_mode_T = TEXTURE_WRAPPING_MODE_CLAMP;
 
-  (*lut)->dielectric_inv->wrap_mode_R = TexModeClamp;
-  (*lut)->dielectric_inv->wrap_mode_S = TexModeClamp;
-  (*lut)->dielectric_inv->wrap_mode_T = TexModeClamp;
+  (*lut)->dielectric_inv->wrap_mode_R = TEXTURE_WRAPPING_MODE_CLAMP;
+  (*lut)->dielectric_inv->wrap_mode_S = TEXTURE_WRAPPING_MODE_CLAMP;
+  (*lut)->dielectric_inv->wrap_mode_T = TEXTURE_WRAPPING_MODE_CLAMP;
 
   return LUMINARY_SUCCESS;
 }

--- a/src/luminary/device/device_cloud.c
+++ b/src/luminary/device/device_cloud.c
@@ -35,15 +35,15 @@ LuminaryResult device_cloud_noise_create(DeviceCloudNoise** cloud_noise, Device*
 
   Texture* shape_tex;
   __FAILURE_HANDLE(texture_create(&shape_tex));
-  __FAILURE_HANDLE(texture_fill(shape_tex, CLOUD_SHAPE_RES, CLOUD_SHAPE_RES, CLOUD_SHAPE_RES, (void*) 0, TexDataUINT8, 4));
+  __FAILURE_HANDLE(texture_fill(shape_tex, CLOUD_SHAPE_RES, CLOUD_SHAPE_RES, CLOUD_SHAPE_RES, (void*) 0, TEXTURE_DATA_TYPE_U8, 4));
 
   Texture* detail_tex;
   __FAILURE_HANDLE(texture_create(&detail_tex));
-  __FAILURE_HANDLE(texture_fill(detail_tex, CLOUD_DETAIL_RES, CLOUD_DETAIL_RES, CLOUD_DETAIL_RES, (void*) 0, TexDataUINT8, 4));
+  __FAILURE_HANDLE(texture_fill(detail_tex, CLOUD_DETAIL_RES, CLOUD_DETAIL_RES, CLOUD_DETAIL_RES, (void*) 0, TEXTURE_DATA_TYPE_U8, 4));
 
   Texture* weather_tex;
   __FAILURE_HANDLE(texture_create(&weather_tex));
-  __FAILURE_HANDLE(texture_fill(weather_tex, CLOUD_WEATHER_RES, CLOUD_WEATHER_RES, 1, (void*) 0, TexDataUINT8, 4));
+  __FAILURE_HANDLE(texture_fill(weather_tex, CLOUD_WEATHER_RES, CLOUD_WEATHER_RES, 1, (void*) 0, TEXTURE_DATA_TYPE_U8, 4));
 
   __FAILURE_HANDLE(device_texture_create(&(*cloud_noise)->shape_tex, shape_tex, device->stream_main));
   __FAILURE_HANDLE(device_texture_create(&(*cloud_noise)->detail_tex, detail_tex, device->stream_main));

--- a/src/luminary/device/device_sky.c
+++ b/src/luminary/device/device_sky.c
@@ -34,29 +34,30 @@ LuminaryResult sky_lut_create(SkyLUT** lut) {
   __FAILURE_HANDLE(texture_create(&(*lut)->multiscattering_low));
   __FAILURE_HANDLE(texture_create(&(*lut)->multiscattering_high));
 
-  __FAILURE_HANDLE(texture_fill((*lut)->transmittance_low, SKY_TM_TEX_WIDTH, SKY_TM_TEX_HEIGHT, 1, transmittance_low_data, TexDataFP32, 4));
   __FAILURE_HANDLE(
-    texture_fill((*lut)->transmittance_high, SKY_TM_TEX_WIDTH, SKY_TM_TEX_HEIGHT, 1, transmittance_high_data, TexDataFP32, 4));
+    texture_fill((*lut)->transmittance_low, SKY_TM_TEX_WIDTH, SKY_TM_TEX_HEIGHT, 1, transmittance_low_data, TEXTURE_DATA_TYPE_FP32, 4));
   __FAILURE_HANDLE(
-    texture_fill((*lut)->multiscattering_low, SKY_MS_TEX_SIZE, SKY_MS_TEX_SIZE, 1, multiscattering_low_data, TexDataFP32, 4));
+    texture_fill((*lut)->transmittance_high, SKY_TM_TEX_WIDTH, SKY_TM_TEX_HEIGHT, 1, transmittance_high_data, TEXTURE_DATA_TYPE_FP32, 4));
   __FAILURE_HANDLE(
-    texture_fill((*lut)->multiscattering_high, SKY_MS_TEX_SIZE, SKY_MS_TEX_SIZE, 1, multiscattering_high_data, TexDataFP32, 4));
+    texture_fill((*lut)->multiscattering_low, SKY_MS_TEX_SIZE, SKY_MS_TEX_SIZE, 1, multiscattering_low_data, TEXTURE_DATA_TYPE_FP32, 4));
+  __FAILURE_HANDLE(
+    texture_fill((*lut)->multiscattering_high, SKY_MS_TEX_SIZE, SKY_MS_TEX_SIZE, 1, multiscattering_high_data, TEXTURE_DATA_TYPE_FP32, 4));
 
-  (*lut)->transmittance_low->wrap_mode_R = TexModeClamp;
-  (*lut)->transmittance_low->wrap_mode_S = TexModeClamp;
-  (*lut)->transmittance_low->wrap_mode_T = TexModeClamp;
+  (*lut)->transmittance_low->wrap_mode_R = TEXTURE_WRAPPING_MODE_CLAMP;
+  (*lut)->transmittance_low->wrap_mode_S = TEXTURE_WRAPPING_MODE_CLAMP;
+  (*lut)->transmittance_low->wrap_mode_T = TEXTURE_WRAPPING_MODE_CLAMP;
 
-  (*lut)->transmittance_high->wrap_mode_R = TexModeClamp;
-  (*lut)->transmittance_high->wrap_mode_S = TexModeClamp;
-  (*lut)->transmittance_high->wrap_mode_T = TexModeClamp;
+  (*lut)->transmittance_high->wrap_mode_R = TEXTURE_WRAPPING_MODE_CLAMP;
+  (*lut)->transmittance_high->wrap_mode_S = TEXTURE_WRAPPING_MODE_CLAMP;
+  (*lut)->transmittance_high->wrap_mode_T = TEXTURE_WRAPPING_MODE_CLAMP;
 
-  (*lut)->multiscattering_low->wrap_mode_R = TexModeClamp;
-  (*lut)->multiscattering_low->wrap_mode_S = TexModeClamp;
-  (*lut)->multiscattering_low->wrap_mode_T = TexModeClamp;
+  (*lut)->multiscattering_low->wrap_mode_R = TEXTURE_WRAPPING_MODE_CLAMP;
+  (*lut)->multiscattering_low->wrap_mode_S = TEXTURE_WRAPPING_MODE_CLAMP;
+  (*lut)->multiscattering_low->wrap_mode_T = TEXTURE_WRAPPING_MODE_CLAMP;
 
-  (*lut)->multiscattering_high->wrap_mode_R = TexModeClamp;
-  (*lut)->multiscattering_high->wrap_mode_S = TexModeClamp;
-  (*lut)->multiscattering_high->wrap_mode_T = TexModeClamp;
+  (*lut)->multiscattering_high->wrap_mode_R = TEXTURE_WRAPPING_MODE_CLAMP;
+  (*lut)->multiscattering_high->wrap_mode_S = TEXTURE_WRAPPING_MODE_CLAMP;
+  (*lut)->multiscattering_high->wrap_mode_T = TEXTURE_WRAPPING_MODE_CLAMP;
 
   return LUMINARY_SUCCESS;
 }
@@ -347,8 +348,8 @@ DEVICE_CTX_FUNC LuminaryResult sky_hdri_generate(SkyHDRI* hdri, Device* device) 
         __FAILURE_HANDLE(texture_create(&hdri->color_tex));
         __FAILURE_HANDLE(texture_create(&hdri->shadow_tex));
 
-        __FAILURE_HANDLE(texture_fill(hdri->color_tex, hdri->width, hdri->height, 1, (void*) 0, TexDataFP32, 4));
-        __FAILURE_HANDLE(texture_fill(hdri->shadow_tex, hdri->width, hdri->height, 1, (void*) 0, TexDataFP32, 1));
+        __FAILURE_HANDLE(texture_fill(hdri->color_tex, hdri->width, hdri->height, 1, (void*) 0, TEXTURE_DATA_TYPE_FP32, 4));
+        __FAILURE_HANDLE(texture_fill(hdri->shadow_tex, hdri->width, hdri->height, 1, (void*) 0, TEXTURE_DATA_TYPE_FP32, 1));
 
         __FAILURE_HANDLE(host_malloc(&hdri->color_tex->data, hdri->color_tex->width * sizeof(RGBAF) * hdri->color_tex->height));
         __FAILURE_HANDLE(host_malloc(&hdri->shadow_tex->data, hdri->shadow_tex->width * sizeof(float) * hdri->shadow_tex->height));

--- a/src/luminary/device/device_structs.c
+++ b/src/luminary/device/device_structs.c
@@ -248,6 +248,7 @@ LuminaryResult device_struct_material_convert(const Material* material, DeviceMa
   device_material->flags |= material->metallic ? DEVICE_MATERIAL_FLAG_METALLIC : 0;
   device_material->flags |= material->colored_transparency ? DEVICE_MATERIAL_FLAG_COLORED_TRANSPARENCY : 0;
   device_material->flags |= material->roughness_as_smoothness ? DEVICE_MATERIAL_FLAG_ROUGHNESS_AS_SMOOTHNESS : 0;
+  device_material->flags |= material->normal_map_is_compressed ? DEVICE_MATERIAL_FLAG_NORMAL_MAP_COMPRESSED : 0;
 
   switch (material->base_substrate) {
     case LUMINARY_MATERIAL_BASE_SUBSTRATE_OPAQUE:

--- a/src/luminary/device/device_structs.h
+++ b/src/luminary/device/device_structs.h
@@ -168,8 +168,9 @@ enum DeviceMaterialFlags {
   DEVICE_MATERIAL_FLAG_THIN_WALLED             = 0x04,
   DEVICE_MATERIAL_FLAG_METALLIC                = 0x08,
   DEVICE_MATERIAL_FLAG_COLORED_TRANSPARENCY    = 0x10,
-  DEVICE_MATERIAL_FLAG_ROUGHNESS_AS_SMOOTHNESS = 0x20
-  // 2 bits unused
+  DEVICE_MATERIAL_FLAG_ROUGHNESS_AS_SMOOTHNESS = 0x20,
+  DEVICE_MATERIAL_FLAG_NORMAL_MAP_COMPRESSED   = 0x40
+  // 1 bits unused
 } typedef DeviceMaterialFlags;
 
 struct DeviceMaterialCompressed {

--- a/src/luminary/device/device_texture.c
+++ b/src/luminary/device/device_texture.c
@@ -4,16 +4,16 @@
 
 static LuminaryResult _device_texture_get_address_mode(const TextureWrappingMode mode, CUaddress_mode* address_mode) {
   switch (mode) {
-    case TexModeWrap:
+    case TEXTURE_WRAPPING_MODE_WRAP:
       *address_mode = CU_TR_ADDRESS_MODE_WRAP;
       return LUMINARY_SUCCESS;
-    case TexModeClamp:
+    case TEXTURE_WRAPPING_MODE_CLAMP:
       *address_mode = CU_TR_ADDRESS_MODE_CLAMP;
       return LUMINARY_SUCCESS;
-    case TexModeMirror:
+    case TEXTURE_WRAPPING_MODE_MIRROR:
       *address_mode = CU_TR_ADDRESS_MODE_MIRROR;
       return LUMINARY_SUCCESS;
-    case TexModeBorder:
+    case TEXTURE_WRAPPING_MODE_BORDER:
       *address_mode = CU_TR_ADDRESS_MODE_BORDER;
       return LUMINARY_SUCCESS;
     default:
@@ -23,14 +23,14 @@ static LuminaryResult _device_texture_get_address_mode(const TextureWrappingMode
 
 static LuminaryResult _device_texture_get_read_mode(const Texture* tex, uint32_t* flags) {
   switch (tex->type) {
-    case TexDataFP32:
+    case TEXTURE_DATA_TYPE_FP32:
       return LUMINARY_SUCCESS;
-    case TexDataUINT8:
-    case TexDataUINT16:
+    case TEXTURE_DATA_TYPE_U8:
+    case TEXTURE_DATA_TYPE_U16:
       switch (tex->read_mode) {
-        case TexReadModeNormalized:
+        case TEXTURE_READ_MODE_NORMALIZED:
           return LUMINARY_SUCCESS;
-        case TexReadModeElement:
+        case TEXTURE_READ_MODE_ELEMENT:
           *flags = *flags | CU_TRSF_READ_AS_INTEGER;
           return LUMINARY_SUCCESS;
         default:
@@ -43,13 +43,13 @@ static LuminaryResult _device_texture_get_read_mode(const Texture* tex, uint32_t
 
 static LuminaryResult _device_texture_get_format(const Texture* tex, CUarray_format* format) {
   switch (tex->type) {
-    case TexDataFP32:
+    case TEXTURE_DATA_TYPE_FP32:
       *format = CU_AD_FORMAT_FLOAT;
       return LUMINARY_SUCCESS;
-    case TexDataUINT8:
+    case TEXTURE_DATA_TYPE_U8:
       *format = CU_AD_FORMAT_UNSIGNED_INT8;
       return LUMINARY_SUCCESS;
-    case TexDataUINT16:
+    case TEXTURE_DATA_TYPE_U16:
       *format = CU_AD_FORMAT_UNSIGNED_INT16;
       return LUMINARY_SUCCESS;
     default:
@@ -59,10 +59,10 @@ static LuminaryResult _device_texture_get_format(const Texture* tex, CUarray_for
 
 static LuminaryResult _device_texture_get_filter_mode(const Texture* tex, CUfilter_mode* mode) {
   switch (tex->filter) {
-    case TexFilterPoint:
+    case TEXTURE_FILTER_MODE_POINT:
       *mode = CU_TR_FILTER_MODE_POINT;
       return LUMINARY_SUCCESS;
-    case TexFilterLinear:
+    case TEXTURE_FILTER_MODE_LINEAR:
       *mode = CU_TR_FILTER_MODE_LINEAR;
       return LUMINARY_SUCCESS;
     default:
@@ -72,13 +72,13 @@ static LuminaryResult _device_texture_get_filter_mode(const Texture* tex, CUfilt
 
 static LuminaryResult _device_texture_get_pixel_size(const Texture* tex, size_t* size) {
   switch (tex->type) {
-    case TexDataFP32:
+    case TEXTURE_DATA_TYPE_FP32:
       *size = tex->num_components * sizeof(float);
       return LUMINARY_SUCCESS;
-    case TexDataUINT8:
+    case TEXTURE_DATA_TYPE_U8:
       *size = tex->num_components * sizeof(uint8_t);
       return LUMINARY_SUCCESS;
-    case TexDataUINT16:
+    case TEXTURE_DATA_TYPE_U16:
       *size = tex->num_components * sizeof(uint16_t);
       return LUMINARY_SUCCESS;
     default:
@@ -124,11 +124,11 @@ LuminaryResult device_texture_create(DeviceTexture** _device_texture, const Text
   size_t pitch_gpu;
 
   switch (texture->dim) {
-    case Tex2D: {
+    case TEXTURE_DIMENSION_TYPE_2D: {
       switch (texture->mipmap) {
         default:
           __RETURN_ERROR(LUMINARY_ERROR_API_EXCEPTION, "Texture mipmap mode is invalid.");
-        case TexMipmapNone: {
+        case TEXTURE_MIPMAP_MODE_NONE: {
           __FAILURE_HANDLE(device_malloc2D(&data_device, width * pixel_size, height));
 
           __FAILURE_HANDLE(device_memory_get_pitch(data_device, &pitch_gpu));
@@ -146,16 +146,16 @@ LuminaryResult device_texture_create(DeviceTexture** _device_texture, const Text
 
           __FAILURE_HANDLE(_device_texture_get_format(texture, &res_desc.res.pitch2D.format));
         } break;
-        case TexMipmapGenerate: {
+        case TEXTURE_MIPMAP_MODE_GENERATE: {
           __RETURN_ERROR(LUMINARY_ERROR_NOT_IMPLEMENTED, "Mipmaps are currently not supported.");
         } break;
       }
     } break;
-    case Tex3D: {
+    case TEXTURE_DIMENSION_TYPE_3D: {
       switch (texture->mipmap) {
         default:
           __RETURN_ERROR(LUMINARY_ERROR_API_EXCEPTION, "Texture mipmap mode is invalid.");
-        case TexMipmapNone: {
+        case TEXTURE_MIPMAP_MODE_NONE: {
           // TODO: Add support in device_memory
 
           CUDA_ARRAY3D_DESCRIPTOR descriptor;
@@ -189,7 +189,7 @@ LuminaryResult device_texture_create(DeviceTexture** _device_texture, const Text
           res_desc.resType          = CU_RESOURCE_TYPE_ARRAY;
           res_desc.res.array.hArray = (CUarray) data_device;
         } break;
-        case TexMipmapGenerate: {
+        case TEXTURE_MIPMAP_MODE_GENERATE: {
           __RETURN_ERROR(LUMINARY_ERROR_NOT_IMPLEMENTED, "Mipmaps are currently not supported.");
         } break;
       }
@@ -221,7 +221,7 @@ LuminaryResult device_texture_create(DeviceTexture** _device_texture, const Text
   device_texture->height     = height;
   device_texture->depth      = depth;
   device_texture->gamma      = texture->gamma;
-  device_texture->is_3D      = (texture->dim == Tex3D);
+  device_texture->is_3D      = (texture->dim == TEXTURE_DIMENSION_TYPE_3D);
   device_texture->pitch      = pitch_gpu;
   device_texture->pixel_size = pixel_size;
 

--- a/src/luminary/host/png.c
+++ b/src/luminary/host/png.c
@@ -491,7 +491,7 @@ LuminaryResult png_load(Texture* texture, const uint8_t* file, const size_t file
 
   const uint32_t byte_per_pixel = byte_per_channel * num_channels;
 
-  const TextureDataType tex_data_type = (bit_depth == PNG_BITDEPTH_8) ? TexDataUINT8 : TexDataUINT16;
+  const TextureDataType tex_data_type = (bit_depth == PNG_BITDEPTH_8) ? TEXTURE_DATA_TYPE_U8 : TEXTURE_DATA_TYPE_U16;
   __FAILURE_HANDLE(texture_fill(texture, width, height, 1, (void*) 0, tex_data_type, 4));
 
   uint8_t* filtered_data;

--- a/src/luminary/host/qoi.c
+++ b/src/luminary/host/qoi.c
@@ -68,11 +68,11 @@ LuminaryResult qoi_encode_RGBA8(const Texture* tex, int* encoded_size, void** da
   __CHECK_NULL_ARGUMENT(encoded_size);
   __CHECK_NULL_ARGUMENT(data);
 
-  if (tex->type != TexDataUINT8) {
+  if (tex->type != TEXTURE_DATA_TYPE_U8) {
     __RETURN_ERROR(LUMINARY_ERROR_API_EXCEPTION, "Texture is not of channel type uint8_t.");
   }
 
-  if (tex->dim != Tex2D) {
+  if (tex->dim != TEXTURE_DIMENSION_TYPE_2D) {
     __RETURN_ERROR(LUMINARY_ERROR_API_EXCEPTION, "Texture is not 2D.");
   }
 
@@ -90,7 +90,7 @@ LuminaryResult qoi_decode_RGBA8(const void* data, const int size, Texture* textu
   qoi_desc desc;
   void* decoded_data = qoi_decode(data, size, &desc, 4);
 
-  __FAILURE_HANDLE(texture_fill(texture, desc.width, desc.height, 1, decoded_data, TexDataUINT8, 4));
+  __FAILURE_HANDLE(texture_fill(texture, desc.width, desc.height, 1, decoded_data, TEXTURE_DATA_TYPE_U8, 4));
 
   return LUMINARY_SUCCESS;
 }

--- a/src/luminary/host/wavefront.c
+++ b/src/luminary/host/wavefront.c
@@ -929,6 +929,12 @@ LuminaryResult wavefront_convert_content(
     mesh->data.index_buffer[ptr * 4 + 1] = t.v2 - 1;
     mesh->data.index_buffer[ptr * 4 + 2] = t.v3 - 1;
 
+    // Some OBJs have no normals. We compute the face normal here and use that instead.
+    // TODO: Implement smooth normals generation.
+    const vec3 face_normal = (vec3) {.x = triangle.edge1.y * triangle.edge2.z - triangle.edge1.z * triangle.edge2.y,
+                                     .y = triangle.edge1.z * triangle.edge2.x - triangle.edge1.x * triangle.edge2.z,
+                                     .z = triangle.edge1.x * triangle.edge2.y - triangle.edge1.y * triangle.edge2.x};
+
     WavefrontUV uv;
 
     const uint32_t vt1_ptr = (t.vt1 > 0) ? t.vt1 - 1 : t.vt1 + uv_count;
@@ -975,9 +981,7 @@ LuminaryResult wavefront_convert_content(
     const uint32_t vn1_ptr = (t.vn1 > 0) ? t.vn1 - 1 : t.vn1 + normal_count;
 
     if (vn1_ptr >= normal_count) {
-      n.x = 0.0f;
-      n.y = 0.0f;
-      n.z = 0.0f;
+      n = face_normal;
     }
     else {
       n = content->normals[vn1_ptr];
@@ -985,9 +989,7 @@ LuminaryResult wavefront_convert_content(
       const float n_length = 1.0f / sqrtf(n.x * n.x + n.y * n.y + n.z * n.z);
 
       if (isnan(n_length) || isinf(n_length)) {
-        n.x = 0.0f;
-        n.y = 0.0f;
-        n.z = 0.0f;
+        n = face_normal;
       }
       else {
         n.x *= n_length;
@@ -1003,9 +1005,7 @@ LuminaryResult wavefront_convert_content(
     const uint32_t vn2_ptr = (t.vn2 > 0) ? t.vn2 - 1 : t.vn2 + normal_count;
 
     if (vn2_ptr >= normal_count) {
-      n.x = 0.0f;
-      n.y = 0.0f;
-      n.z = 0.0f;
+      n = face_normal;
     }
     else {
       n = content->normals[vn2_ptr];
@@ -1013,9 +1013,7 @@ LuminaryResult wavefront_convert_content(
       const float n_length = 1.0f / sqrtf(n.x * n.x + n.y * n.y + n.z * n.z);
 
       if (isnan(n_length) || isinf(n_length)) {
-        n.x = 0.0f;
-        n.y = 0.0f;
-        n.z = 0.0f;
+        n = face_normal;
       }
       else {
         n.x *= n_length;
@@ -1031,9 +1029,7 @@ LuminaryResult wavefront_convert_content(
     const uint32_t vn3_ptr = (t.vn3 > 0) ? t.vn3 - 1 : t.vn3 + normal_count;
 
     if (vn3_ptr >= normal_count) {
-      n.x = 0.0f;
-      n.y = 0.0f;
-      n.z = 0.0f;
+      n = face_normal;
     }
     else {
       n = content->normals[vn3_ptr];
@@ -1041,9 +1037,7 @@ LuminaryResult wavefront_convert_content(
       const float n_length = 1.0f / sqrtf(n.x * n.x + n.y * n.y + n.z * n.z);
 
       if (isnan(n_length) || isinf(n_length)) {
-        n.x = 0.0f;
-        n.y = 0.0f;
-        n.z = 0.0f;
+        n = face_normal;
       }
       else {
         n.x *= n_length;

--- a/src/luminary/host/wavefront.c
+++ b/src/luminary/host/wavefront.c
@@ -11,6 +11,7 @@
 
 #include "internal_error.h"
 #include "internal_path.h"
+#include "material.h"
 #include "png.h"
 #include "utils.h"
 
@@ -788,26 +789,29 @@ static LuminaryResult _wavefront_convert_materials(WavefrontContent* content, AR
     const bool has_emission = (wavefront_mat.emission.r > 0.0f) || (wavefront_mat.emission.g > 0.0f) || (wavefront_mat.emission.b > 0.0f);
 
     Material mat;
-    mat.id                      = material_id_offset + mat_id;
-    mat.base_substrate          = LUMINARY_MATERIAL_BASE_SUBSTRATE_OPAQUE;
-    mat.albedo.r                = wavefront_mat.diffuse_reflectivity.r;
-    mat.albedo.g                = wavefront_mat.diffuse_reflectivity.g;
-    mat.albedo.b                = wavefront_mat.diffuse_reflectivity.b;
-    mat.albedo.a                = wavefront_mat.dissolve;
-    mat.emission                = wavefront_mat.emission;
-    mat.emission_scale          = content->args.emission_scale;
-    mat.refraction_index        = wavefront_mat.refraction_index;
-    mat.roughness               = 1.0f - wavefront_mat.specular_exponent / 1000.0f;
-    mat.roughness_clamp         = 0.25f;
-    mat.roughness_as_smoothness = content->args.legacy_smoothness;
-    mat.emission_active         = has_luminance_tex || has_emission;
-    mat.thin_walled             = false;
-    mat.metallic                = wavefront_mat.specular_reflectivity.r > 0.5f;
-    mat.albedo_tex              = has_albedo_tex ? texture_offset + wavefront_mat.texture[WF_ALBEDO] : TEXTURE_NONE;
-    mat.luminance_tex           = has_luminance_tex ? texture_offset + wavefront_mat.texture[WF_LUMINANCE] : TEXTURE_NONE;
-    mat.roughness_tex           = has_roughness_tex ? texture_offset + wavefront_mat.texture[WF_ROUGHNESS] : TEXTURE_NONE;
-    mat.metallic_tex            = has_metallic_tex ? texture_offset + wavefront_mat.texture[WF_METALLIC] : TEXTURE_NONE;
-    mat.normal_tex              = has_normal_tex ? texture_offset + wavefront_mat.texture[WF_NORMAL] : TEXTURE_NONE;
+    __FAILURE_HANDLE(material_get_default(&mat));
+
+    mat.id                       = material_id_offset + mat_id;
+    mat.base_substrate           = LUMINARY_MATERIAL_BASE_SUBSTRATE_OPAQUE;
+    mat.albedo.r                 = wavefront_mat.diffuse_reflectivity.r;
+    mat.albedo.g                 = wavefront_mat.diffuse_reflectivity.g;
+    mat.albedo.b                 = wavefront_mat.diffuse_reflectivity.b;
+    mat.albedo.a                 = wavefront_mat.dissolve;
+    mat.emission                 = wavefront_mat.emission;
+    mat.emission_scale           = content->args.emission_scale;
+    mat.refraction_index         = wavefront_mat.refraction_index;
+    mat.roughness                = 1.0f - wavefront_mat.specular_exponent / 1000.0f;
+    mat.roughness_clamp          = 0.25f;
+    mat.roughness_as_smoothness  = content->args.legacy_smoothness;
+    mat.emission_active          = has_luminance_tex || has_emission;
+    mat.thin_walled              = false;
+    mat.normal_map_is_compressed = true;
+    mat.metallic                 = wavefront_mat.specular_reflectivity.r > 0.5f;
+    mat.albedo_tex               = has_albedo_tex ? texture_offset + wavefront_mat.texture[WF_ALBEDO] : TEXTURE_NONE;
+    mat.luminance_tex            = has_luminance_tex ? texture_offset + wavefront_mat.texture[WF_LUMINANCE] : TEXTURE_NONE;
+    mat.roughness_tex            = has_roughness_tex ? texture_offset + wavefront_mat.texture[WF_ROUGHNESS] : TEXTURE_NONE;
+    mat.metallic_tex             = has_metallic_tex ? texture_offset + wavefront_mat.texture[WF_METALLIC] : TEXTURE_NONE;
+    mat.normal_tex               = has_normal_tex ? texture_offset + wavefront_mat.texture[WF_NORMAL] : TEXTURE_NONE;
 
     __FAILURE_HANDLE(array_push(materials, &mat));
   }

--- a/src/luminary/host/wavefront.h
+++ b/src/luminary/host/wavefront.h
@@ -8,17 +8,8 @@
 #include "texture.h"
 #include "utils.h"
 
-struct WavefrontVertex {
-  float x;
-  float y;
-  float z;
-} typedef WavefrontVertex;
-
-struct WavefrontNormal {
-  float x;
-  float y;
-  float z;
-} typedef WavefrontNormal;
+typedef vec3 WavefrontVertex;
+typedef vec3 WavefrontNormal;
 
 struct WavefrontUV {
   float u;

--- a/src/luminary/host_memory.c
+++ b/src/luminary/host_memory.c
@@ -86,27 +86,6 @@ static LuminaryResult _debug_memory_allocation_add(
   return LUMINARY_SUCCESS;
 }
 
-static LuminaryResult _debug_memory_allocation_resize(
-  const void* old_ptr, const void* new_ptr, const char* buf_name, const char* func, uint32_t line, const size_t size) {
-  mtx_lock(&_memory_debug_mutex);
-
-  const char* allocation_name = _debug_memory_allocation_get_name(buf_name, func, line);
-
-  MemoryDebugAllocation* allocation = _debug_memory_allocation_find(old_ptr);
-
-  if (!allocation) {
-    mtx_unlock(&_memory_debug_mutex);
-    __RETURN_ERROR(LUMINARY_ERROR_MEMORY_LEAK, "LUMINARY_MEMORY_DEBUG Allocation %s does not exist.", allocation_name);
-  }
-
-  allocation->size = size;
-  allocation->ptr  = new_ptr;
-
-  mtx_unlock(&_memory_debug_mutex);
-
-  return LUMINARY_SUCCESS;
-}
-
 static LuminaryResult _debug_memory_allocation_remove(
   const void* ptr, const char* buf_name, const char* func, uint32_t line, const size_t size) {
   mtx_lock(&_memory_debug_mutex);
@@ -215,6 +194,10 @@ LuminaryResult _host_realloc(void** ptr, size_t size, const char* buf_name, cons
 
   atomic_fetch_sub(&_host_memory_total_allocation, header->size);
 
+#ifdef LUMINARY_MEMORY_DEBUG
+  _debug_memory_allocation_remove(*ptr, buf_name, func, line, header->size);
+#endif /* LUMINARY_MEMORY_DEBUG */
+
   header = realloc(header, (uint64_t) size + sizeof(struct HostMemoryHeader));
 
   header->size = size;
@@ -223,7 +206,7 @@ LuminaryResult _host_realloc(void** ptr, size_t size, const char* buf_name, cons
   LUM_UNUSED(prev_total);
 
 #ifdef LUMINARY_MEMORY_DEBUG
-  _debug_memory_allocation_resize(*ptr, (const void*) (header + 1), buf_name, func, line, size);
+  _debug_memory_allocation_add((const void*) (header + 1), buf_name, func, line, size);
   luminary_print_log("Realloc %012llu [Total: %012llu] [%s:%u]: %s", size, prev_total + size, func, line, buf_name);
 #endif /* LUMINARY_MEMORY_DEBUG */
 

--- a/src/luminary/host_memory.c
+++ b/src/luminary/host_memory.c
@@ -35,8 +35,8 @@ struct MemoryDebugAllocation {
 } typedef MemoryDebugAllocation;
 
 static MemoryDebugAllocation* _debug_memory_allocations;
-uint64_t _debug_memory_allocations_count;
-uint64_t _debug_memory_allocations_allocated;
+static uint64_t _debug_memory_allocations_count;
+static uint64_t _debug_memory_allocations_allocated;
 
 static MemoryDebugAllocation* _debug_memory_allocation_find(const void* ptr) {
   for (uint64_t allocation = 0; allocation < _debug_memory_allocations_count; allocation++) {

--- a/src/luminary/image.c
+++ b/src/luminary/image.c
@@ -30,6 +30,7 @@ static void* _image_realloc_stbi(void* data, size_t size) {
 
 #define STB_IMAGE_IMPLEMENTATION
 #define STB_IMAGE_STATIC
+#define STBI_NO_FAILURE_STRINGS
 #define STBI_ASSERT(x)
 #ifdef __WIN32__
 #define STBI_WINDOWS_UTF8

--- a/src/luminary/image.c
+++ b/src/luminary/image.c
@@ -1,0 +1,152 @@
+#include "image.h"
+
+#include "internal_error.h"
+
+static void* _image_malloc_stbi(size_t size) {
+  void* data;
+  LuminaryResult result = host_malloc(&data, size);
+
+  return (result == LUMINARY_SUCCESS) ? data : (void*) 0;
+}
+
+static void _image_free_stbi(void* data) {
+  if (data == (void*) 0)
+    return;
+
+  (void) host_free(&data);
+}
+
+static void* _image_realloc_stbi(void* data, size_t size) {
+  LuminaryResult result;
+  if (data == (void*) 0) {
+    result = host_malloc(&data, size);
+  }
+  else {
+    result = host_realloc(&data, size);
+  }
+
+  return (result == LUMINARY_SUCCESS) ? data : (void*) 0;
+}
+
+#define STB_IMAGE_IMPLEMENTATION
+#define STB_IMAGE_STATIC
+#define STBI_ASSERT(x)
+#ifdef __WIN32__
+#define STBI_WINDOWS_UTF8
+#endif /* __WIN32__ */
+
+#define STBI_MALLOC(sz) _image_malloc_stbi(sz)
+#define STBI_REALLOC(p, newsz) _image_realloc_stbi(p, newsz)
+#define STBI_FREE(p) _image_free_stbi(p)
+
+// Disable warnings about unused static functions in stb_image. We assume that all non-MSVC compilers support GCC style pragmas.
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(push)
+#pragma warning(disable : 4505)
+#else /* _MSC_VER && !__clang__ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif /* !_MSC_VER || __clang__ */
+
+#include "stb/stb_image.h"
+
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(pop)
+#else /* _MSC_VER && !__clang__ */
+#pragma GCC diagnostic pop
+#endif /* !_MSC_VER || __clang__ */
+
+static LuminaryResult _image_load_hdr(Texture* texture, const uint8_t* file_mem, size_t file_length) {
+  __CHECK_NULL_ARGUMENT(texture);
+  __CHECK_NULL_ARGUMENT(file_mem);
+
+  int width, height, num_components;
+  float* data = stbi_loadf_from_memory(file_mem, (int) file_length, &width, &height, &num_components, 4);
+
+  __FAILURE_HANDLE(texture_fill(texture, width, height, 1, data, TEXTURE_DATA_TYPE_FP32, 4));
+
+  // stb_image does not expose this so we have to guess
+  texture->gamma = 1.0f;
+
+  return LUMINARY_SUCCESS;
+}
+
+static LuminaryResult _image_load_16(Texture* texture, const uint8_t* file_mem, size_t file_length) {
+  __CHECK_NULL_ARGUMENT(texture);
+  __CHECK_NULL_ARGUMENT(file_mem);
+
+  int width, height, num_components;
+  uint16_t* data = stbi_load_16_from_memory(file_mem, (int) file_length, &width, &height, &num_components, 4);
+
+  __FAILURE_HANDLE(texture_fill(texture, width, height, 1, data, TEXTURE_DATA_TYPE_U16, 4));
+
+  // stb_image does not expose this so we have to guess
+  texture->gamma = 2.2f;
+
+  return LUMINARY_SUCCESS;
+}
+
+static LuminaryResult _image_load_8(Texture* texture, const uint8_t* file_mem, size_t file_length) {
+  __CHECK_NULL_ARGUMENT(texture);
+  __CHECK_NULL_ARGUMENT(file_mem);
+
+  int width, height, num_components;
+  uint8_t* data = stbi_load_from_memory(file_mem, (int) file_length, &width, &height, &num_components, 4);
+
+  __FAILURE_HANDLE(texture_fill(texture, width, height, 1, data, TEXTURE_DATA_TYPE_U8, 4));
+
+  // stb_image does not expose this so we have to guess
+  // TODO: Expose this as a per texture setting through the API one day so users can manually fix this.
+  texture->gamma = 2.2f;
+
+  return LUMINARY_SUCCESS;
+}
+
+LuminaryResult image_load(Texture* texture, const char* path) {
+  __CHECK_NULL_ARGUMENT(texture);
+  __CHECK_NULL_ARGUMENT(path);
+
+  log_message("Loading texture file (%s)", path);
+
+  FILE* file = fopen(path, "rb");
+
+  if (!file) {
+    __FAILURE_HANDLE(texture_invalidate(texture));
+    __RETURN_ERROR(LUMINARY_ERROR_API_EXCEPTION, "File %s could not be opened!", path);
+  }
+
+  // Block size is very important for performance, it seems that the larger this is the better,
+  // however, too large block sizes also means large memory consumption.
+  const size_t block_size = 16 * 1024 * 1024;
+  size_t file_length      = 0;
+
+  uint8_t* file_mem;
+  __FAILURE_HANDLE(host_malloc(&file_mem, block_size));
+
+  size_t read_size;
+
+  while (read_size = fread(file_mem + file_length, 1, block_size, file), read_size == block_size) {
+    file_length += block_size;
+    __FAILURE_HANDLE(host_realloc(&file_mem, file_length + block_size));
+  }
+
+  fclose(file);
+
+  file_length += read_size;
+
+  __FAILURE_HANDLE(host_realloc(&file_mem, file_length));
+
+  if (stbi_is_hdr_from_memory(file_mem, (int) file_length)) {
+    __FAILURE_HANDLE(_image_load_hdr(texture, file_mem, file_length));
+  }
+  else if (stbi_is_16_bit_from_memory(file_mem, (int) file_length)) {
+    __FAILURE_HANDLE(_image_load_16(texture, file_mem, file_length));
+  }
+  else {
+    __FAILURE_HANDLE(_image_load_8(texture, file_mem, file_length));
+  }
+
+  __FAILURE_HANDLE(host_free(&file_mem));
+
+  return LUMINARY_SUCCESS;
+}

--- a/src/luminary/image.h
+++ b/src/luminary/image.h
@@ -1,0 +1,9 @@
+#ifndef LUMINARY_IMAGE_H
+#define LUMINARY_IMAGE_H
+
+#include "texture.h"
+#include "utils.h"
+
+LuminaryResult image_load(Texture* texture, const char* path);
+
+#endif /* LUMINARY_IMAGE_H */

--- a/src/luminary/material.c
+++ b/src/luminary/material.c
@@ -5,23 +5,24 @@
 LuminaryResult material_get_default(Material* material) {
   __CHECK_NULL_ARGUMENT(material);
 
-  material->id                   = 0;
-  material->base_substrate       = LUMINARY_MATERIAL_BASE_SUBSTRATE_OPAQUE;
-  material->albedo               = (RGBAF) {.r = 0.9f, .g = 0.9f, .b = 0.9f, .a = 0.9f};
-  material->emission             = (RGBF) {.r = 0.0f, .g = 0.0f, .b = 0.0f};
-  material->emission_scale       = 1.0f;
-  material->roughness            = 0.7f;
-  material->roughness_clamp      = 0.25f;
-  material->refraction_index     = 1.0f;
-  material->emission_active      = false;
-  material->thin_walled          = false;
-  material->metallic             = false;
-  material->colored_transparency = false;
-  material->albedo_tex           = TEXTURE_NONE;
-  material->luminance_tex        = TEXTURE_NONE;
-  material->roughness_tex        = TEXTURE_NONE;
-  material->metallic_tex         = TEXTURE_NONE;
-  material->normal_tex           = TEXTURE_NONE;
+  material->id                       = 0;
+  material->base_substrate           = LUMINARY_MATERIAL_BASE_SUBSTRATE_OPAQUE;
+  material->albedo                   = (RGBAF) {.r = 0.9f, .g = 0.9f, .b = 0.9f, .a = 0.9f};
+  material->emission                 = (RGBF) {.r = 0.0f, .g = 0.0f, .b = 0.0f};
+  material->emission_scale           = 1.0f;
+  material->roughness                = 0.7f;
+  material->roughness_clamp          = 0.25f;
+  material->refraction_index         = 1.0f;
+  material->emission_active          = false;
+  material->thin_walled              = false;
+  material->metallic                 = false;
+  material->colored_transparency     = false;
+  material->normal_map_is_compressed = true;
+  material->albedo_tex               = TEXTURE_NONE;
+  material->luminance_tex            = TEXTURE_NONE;
+  material->roughness_tex            = TEXTURE_NONE;
+  material->metallic_tex             = TEXTURE_NONE;
+  material->normal_tex               = TEXTURE_NONE;
 
   return LUMINARY_SUCCESS;
 }
@@ -91,6 +92,7 @@ LuminaryResult material_check_for_dirty(const Material* input, const Material* o
   __MATERIAL_DIRTY(emission_active);
   __MATERIAL_DIRTY(colored_transparency);
   __MATERIAL_DIRTY(roughness_as_smoothness);
+  __MATERIAL_DIRTY(normal_map_is_compressed);
 
   return LUMINARY_SUCCESS;
 }

--- a/src/luminary/texture.c
+++ b/src/luminary/texture.c
@@ -1,9 +1,11 @@
 #include "texture.h"
 
 #include <stdatomic.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "host/png.h"
+#include "image.h"
 #include "internal_error.h"
 #include "queue_worker.h"
 #include "spinlock.h"
@@ -26,7 +28,7 @@ static LuminaryResult _texture_load_async_queue_work(void* context, TextureAsync
   // Context-less
   (void) context;
 
-  LuminaryResult result = png_load_from_file(work->texture, work->path);
+  LuminaryResult result = image_load(work->texture, work->path);
 
   work->success = result == LUMINARY_SUCCESS;
 
@@ -58,11 +60,11 @@ static LuminaryResult _texture_load_async_clear_work(void* context, TextureAsync
 
 static uint32_t _texture_compute_pitch(const uint32_t width, TextureDataType type, uint32_t num_components) {
   switch (type) {
-    case TexDataFP32:
+    case TEXTURE_DATA_TYPE_FP32:
       return 4 * num_components * width;
-    case TexDataUINT8:
+    case TEXTURE_DATA_TYPE_U8:
       return 1 * num_components * width;
-    case TexDataUINT16:
+    case TEXTURE_DATA_TYPE_U16:
       return 2 * num_components * width;
     default:
       return 0;
@@ -88,14 +90,14 @@ LuminaryResult texture_fill(
   tex->depth            = depth;
   tex->pitch            = _texture_compute_pitch(width, type, num_components);
   tex->data             = data;
-  tex->dim              = (depth > 1) ? Tex3D : Tex2D;
+  tex->dim              = (depth > 1) ? TEXTURE_DIMENSION_TYPE_3D : TEXTURE_DIMENSION_TYPE_2D;
   tex->type             = type;
-  tex->wrap_mode_S      = TexModeWrap;
-  tex->wrap_mode_T      = TexModeWrap;
-  tex->wrap_mode_R      = TexModeWrap;
-  tex->filter           = TexFilterLinear;
-  tex->read_mode        = TexReadModeNormalized;
-  tex->mipmap           = TexMipmapNone;
+  tex->wrap_mode_S      = TEXTURE_WRAPPING_MODE_WRAP;
+  tex->wrap_mode_T      = TEXTURE_WRAPPING_MODE_WRAP;
+  tex->wrap_mode_R      = TEXTURE_WRAPPING_MODE_WRAP;
+  tex->filter           = TEXTURE_FILTER_MODE_LINEAR;
+  tex->read_mode        = TEXTURE_READ_MODE_NORMALIZED;
+  tex->mipmap           = TEXTURE_MIPMAP_MODE_NONE;
   tex->mipmap_max_level = 0;
   tex->gamma            = 1.0f;
   tex->num_components   = num_components;

--- a/src/luminary/texture.h
+++ b/src/luminary/texture.h
@@ -4,13 +4,17 @@
 #include "utils.h"
 
 enum TextureStatus { TEXTURE_STATUS_NONE, TEXTURE_STATUS_INVALID, TEXTURE_STATUS_ASYNC_LOADING } typedef TextureStatus;
-
-enum TextureDataType { TexDataFP32 = 0, TexDataUINT8 = 1, TexDataUINT16 = 2 } typedef TextureDataType;
-enum TextureWrappingMode { TexModeWrap = 0, TexModeClamp = 1, TexModeMirror = 2, TexModeBorder = 3 } typedef TextureWrappingMode;
-enum TextureDimensionType { Tex2D = 0, Tex3D = 1 } typedef TextureDimensionType;
-enum TextureFilterMode { TexFilterPoint = 0, TexFilterLinear = 1 } typedef TextureFilterMode;
-enum TextureMipmapMode { TexMipmapNone = 0, TexMipmapGenerate = 1 } typedef TextureMipmapMode;
-enum TextureReadMode { TexReadModeNormalized = 0, TexReadModeElement = 1 } typedef TextureReadMode;
+enum TextureDataType { TEXTURE_DATA_TYPE_FP32, TEXTURE_DATA_TYPE_U8, TEXTURE_DATA_TYPE_U16 } typedef TextureDataType;
+enum TextureWrappingMode {
+  TEXTURE_WRAPPING_MODE_WRAP,
+  TEXTURE_WRAPPING_MODE_CLAMP,
+  TEXTURE_WRAPPING_MODE_MIRROR,
+  TEXTURE_WRAPPING_MODE_BORDER
+} typedef TextureWrappingMode;
+enum TextureDimensionType { TEXTURE_DIMENSION_TYPE_2D, TEXTURE_DIMENSION_TYPE_3D } typedef TextureDimensionType;
+enum TextureFilterMode { TEXTURE_FILTER_MODE_POINT, TEXTURE_FILTER_MODE_LINEAR } typedef TextureFilterMode;
+enum TextureMipmapMode { TEXTURE_MIPMAP_MODE_NONE, TEXTURE_MIPMAP_MODE_GENERATE } typedef TextureMipmapMode;
+enum TextureReadMode { TEXTURE_READ_MODE_NORMALIZED, TEXTURE_READ_MODE_ELEMENT } typedef TextureReadMode;
 
 struct Texture {
   TextureStatus status;

--- a/src/mandarin_duck/windows/entity_properties.c
+++ b/src/mandarin_duck/windows/entity_properties.c
@@ -724,6 +724,10 @@ static void _window_entity_properties_material_action(Window* window, Display* d
       _window_entity_properties_add_slider(data, "IOR", &material.refraction_index, ELEMENT_SLIDER_DATA_TYPE_FLOAT, 1.0f, 3.0f, 1.0f);
   }
 
+  if (material.normal_tex != 0xFFFF) {
+    update_data |= _window_entity_properties_add_checkbox(data, "Compressed Normal Map", &material.normal_map_is_compressed);
+  }
+
   update_data |= _window_entity_properties_add_checkbox(data, "Colored Transparency", &material.colored_transparency);
   update_data |= _window_entity_properties_add_checkbox(data, "Roughness as Smoothness", &material.roughness_as_smoothness);
 


### PR DESCRIPTION
Textures now use the stb_image library to load files. This adds support for a lot more image formats. However, EXR and DDS files are still not supported.

PNG color space encoding is shotty. The old PNG implementation was always honoring what the PNG meta data specified. stb_image does not do that so all PNG files are assumed to be sRGB encoded from here on.

I also identified some issues with normals and normal mapping that were fixed.